### PR TITLE
Fix timeline creating branches for brief transitional overlaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to CV Manager will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/), versioning follows [Semantic Versioning](https://semver.org/).
 
+## [1.12.1] - 2026-03-03
+
+### Fixed
+- Timeline no longer creates visual branches for brief transitional overlaps (e.g. starting a new role a few months before leaving the old one); only genuinely concurrent positions trigger branching
+
 ## [1.12.0] - 2026-03-03
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cv-manager",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cv-manager",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "dependencies": {
         "better-sqlite3": "^9.4.3",
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cv-manager",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Professional CV Management System",
   "main": "src/server.js",
   "scripts": {

--- a/public/shared/scripts.js
+++ b/public/shared/scripts.js
@@ -372,7 +372,12 @@ function computeTimelineBranches(items) {
         const overlapping = [];
         for (let j = 0; j < i; j++) {
             const overlapMonths = Math.min(segments[j].endMonths, segments[i].endMonths) - segments[i].startMonths;
-            if (overlapMonths >= minOverlap) {
+            // Require both absolute minimum overlap AND that the overlap covers
+            // at least half the current item's duration. This prevents brief
+            // transitional overlaps (starting a new role months before leaving
+            // the old one) from creating visual branches — only genuinely
+            // concurrent positions should branch.
+            if (overlapMonths >= minOverlap && overlapMonths >= durationI * 0.5) {
                 overlapping.push(j);
             }
         }

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.12.0",
+  "version": "1.12.1",
   "changelog": "https://github.com/vincentmakes/cv-manager/blob/main/CHANGELOG.md"
 }


### PR DESCRIPTION
The branch detection algorithm now requires that overlap covers at least 50% of the item's duration before creating a visual branch. This prevents brief job transitions (starting a new role a few months before leaving the old one) from triggering the branch visualization, which looked broken when the overlap was minor relative to the job's total duration.

https://claude.ai/code/session_017GNjmnVbiG7o17kAEUEZfe