### PR TITLE
Fix ATS PDF extraction and improve accessibility with aria-hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to CV Manager will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/), versioning follows [Semantic Versioning](https://semver.org/).
 
+## [1.22.1] - 2026-03-06
+
+### Fixed
+- ATS-friendly content block now included in PDF print output (was incorrectly hidden with `display: none`)
+- Added `aria-hidden` to decorative icon elements for better screen reader and ATS parser compatibility
+
 ## [1.22.0] - 2026-03-05
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cv-manager",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cv-manager",
-      "version": "1.22.0",
+      "version": "1.22.1",
       "dependencies": {
         "better-sqlite3": "^9.4.3",
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cv-manager",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "description": "Professional CV Management System",
   "main": "src/server.js",
   "scripts": {

--- a/public/shared/scripts.js
+++ b/public/shared/scripts.js
@@ -2,7 +2,7 @@
 
 // Material Icon helper function
 function materialIcon(name, size = 16) {
-    return `<span class="material-symbols-outlined" style="font-size:${size}px">${name}</span>`;
+    return `<span class="material-symbols-outlined" aria-hidden="true" style="font-size:${size}px">${name}</span>`;
 }
 
 // Icons for contact badges and skill categories
@@ -10,7 +10,7 @@ const icons = {
     email: materialIcon('email', 14),
     phone: materialIcon('phone', 14),
     location: materialIcon('location_on', 14),
-    linkedin: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/><rect x="2" y="9" width="4" height="12"/><circle cx="4" cy="4" r="2"/></svg>',
+    linkedin: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/><rect x="2" y="9" width="4" height="12"/><circle cx="4" cy="4" r="2"/></svg>',
     languages: materialIcon('language', 14),
     link: materialIcon('open_in_new', 14),
     // Skill category icons

--- a/public/shared/styles.css
+++ b/public/shared/styles.css
@@ -1143,20 +1143,8 @@ body.has-preview-banner .container {
     border: 0;
 }
 
-/* ATS-friendly print version - show structured text for PDF extraction */
-@media print {
-    .ats-only {
-        position: static;
-        width: auto;
-        height: auto;
-        padding: 0;
-        margin: 0;
-        overflow: visible;
-        clip: auto;
-        white-space: pre-wrap;
-        display: none; /* Hide in print since visual version is better structured now */
-    }
-}
+/* ATS-friendly print version - keep sr-only technique so text is in PDF text layer for ATS extraction */
+/* The base .ats-only rule above already uses the correct clip method. No print override needed. */
 
 /* Print Styles */
 @media print {

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.22.0",
+  "version": "1.22.1",
   "changelog": "https://github.com/vincentmakes/cv-manager/blob/main/CHANGELOG.md"
 }


### PR DESCRIPTION
## Summary
This release fixes ATS (Applicant Tracking System) PDF extraction by removing an incorrect `display: none` rule that was hiding ATS-friendly content in print output, and improves accessibility by adding `aria-hidden="true"` to decorative icon elements.

## Key Changes
- **Fixed ATS PDF extraction**: Removed the `@media print` override that was hiding `.ats-only` content with `display: none`. The base `.ats-only` styling using the clip method is sufficient for proper PDF text layer inclusion while maintaining visual hiding on screen.
- **Improved accessibility**: Added `aria-hidden="true"` attribute to all decorative icon elements:
  - Material icon spans in `materialIcon()` helper function
  - LinkedIn SVG icon in the icons object
- **Updated version**: Bumped to 1.22.1 and updated CHANGELOG

## Implementation Details
The ATS-friendly content now properly appears in PDF text layers for ATS parser extraction, while the visual presentation remains unchanged. Decorative icons are now properly marked as hidden from assistive technologies and ATS parsers, reducing noise in extracted content.

https://claude.ai/code/session_0162st6nVMzvVK3jehDDg74X