### PR TITLE
Add credential URL validation and link rendering for certifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to CV Manager will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/), versioning follows [Semantic Versioning](https://semver.org/).
 
+## [1.26.4] - 2026-04-14
+
+### Fixed
+- Certifications: the credential field is now treated as a URL and renders a link icon (opens in a new tab) on both the admin and public views, matching the Projects section. Previously the value was stored but never rendered, and was stripped from the public API.
+
+### Added
+- Client- and server-side URL validation for certification credential URLs (http/https only).
+- Renamed the field label to "Credential URL" across all 8 locales and added a URL placeholder.
+- New i18n keys: `form.credential_url`, `form.credential_url_placeholder`, `toast.credential_url_invalid`, `view_credential`.
+
+### Changed
+- Demo data: sample `credential_id` values in `demo-cv-data.json` are now example verification URLs so fresh installs demonstrate the link-icon feature.
+
 ## [1.26.3] - 2026-04-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to CV Manager will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/), versioning follows [Semantic Versioning](https://semver.org/).
 
+## [1.26.5] - 2026-04-14
+
+### Fixed
+- Certification link icon no longer shows an underline on hover/focus
+- Certification link icon is hidden in print output (previously it printed as a small rendered box)
+- Dataset view (`/v/:slug`) now also renders the certification credential URL as a link icon (only the live `/` public view did before)
+
 ## [1.26.4] - 2026-04-14
 
 ### Fixed

--- a/demo-cv-data.json
+++ b/demo-cv-data.json
@@ -96,7 +96,7 @@
       "provider": "Amazon Web Services",
       "issue_date": "2023-06",
       "expiry_date": "2026-06",
-      "credential_id": "AWS-SAP-12345",
+      "credential_id": "https://www.credly.com/badges/example/aws-sap-12345",
       "visible": true
     },
     {
@@ -104,7 +104,7 @@
       "provider": "Microsoft",
       "issue_date": "2023-01",
       "expiry_date": "2025-01",
-      "credential_id": "MS-AZ305-67890",
+      "credential_id": "https://learn.microsoft.com/api/credentials/share/example/AZ-305/67890",
       "visible": true
     },
     {
@@ -112,7 +112,7 @@
       "provider": "CNCF",
       "issue_date": "2022-08",
       "expiry_date": "2025-08",
-      "credential_id": "CKA-2022-MC",
+      "credential_id": "https://www.credly.com/badges/example/cka-2022-mc",
       "visible": true
     },
     {
@@ -120,7 +120,7 @@
       "provider": "HashiCorp",
       "issue_date": "2022-03",
       "expiry_date": "2024-03",
-      "credential_id": "HC-TFA-11111",
+      "credential_id": "https://www.credly.com/badges/example/hashicorp-terraform-associate",
       "visible": true
     },
     {
@@ -128,7 +128,7 @@
       "provider": "Google",
       "issue_date": "2021-11",
       "expiry_date": "2023-11",
-      "credential_id": "GCP-PCA-22222",
+      "credential_id": "https://www.credential.net/example/gcp-pca-22222",
       "visible": true
     },
     {
@@ -136,7 +136,7 @@
       "provider": "The Open Group",
       "issue_date": "2020-05",
       "expiry_date": null,
-      "credential_id": "TOGAF-33333",
+      "credential_id": "https://www.opengroup.org/certifications/verify/example/TOGAF-33333",
       "visible": true
     }
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cv-manager",
-  "version": "1.26.3",
+  "version": "1.26.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cv-manager",
-      "version": "1.26.3",
+      "version": "1.26.4",
       "dependencies": {
         "archiver": "^7.0.1",
         "better-sqlite3": "^9.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cv-manager",
-  "version": "1.26.4",
+  "version": "1.26.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cv-manager",
-      "version": "1.26.4",
+      "version": "1.26.5",
       "dependencies": {
         "archiver": "^7.0.1",
         "better-sqlite3": "^9.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cv-manager",
-  "version": "1.26.3",
+  "version": "1.26.4",
   "description": "Professional CV Management System",
   "main": "src/server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cv-manager",
-  "version": "1.26.4",
+  "version": "1.26.5",
   "description": "Professional CV Management System",
   "main": "src/server.js",
   "scripts": {

--- a/public-readonly/index.html
+++ b/public-readonly/index.html
@@ -477,11 +477,15 @@
             const visible = certs.filter(c => c.visible !== false);
             document.getElementById('certGrid').innerHTML = visible.map(cert => {
                 const hasLogo = !!cert.logo_filename;
+                const hasLink = isValidUrl(cert.credential_id);
                 return `
                 <article class="cert-card${hasLogo ? ' has-logo' : ''}" itemscope itemtype="https://schema.org/EducationalOccupationalCredential">
                     ${hasLogo ? `<img src="/uploads/${encodeURIComponent(cert.logo_filename)}" class="cert-logo" alt="${escapeHtml(cert.provider || '')}" onerror="this.style.display='none'">` : ''}
                     <div class="cert-content">
-                        <div class="cert-name" itemprop="name">${escapeHtml(cert.name)}</div>
+                        <div class="cert-header">
+                            <div class="cert-name" itemprop="name">${escapeHtml(cert.name)}</div>
+                            ${hasLink ? `<a href="${escapeHtml(cert.credential_id)}" class="cert-link" target="_blank" rel="noopener" itemprop="url" title="${t('view_credential')}">${icons.link}</a>` : ''}
+                        </div>
                         <time class="cert-date" itemprop="dateCreated">${formatDate(cert.issue_date) || escapeHtml(cert.issue_date || '')}</time>
                         <div class="cert-provider" itemprop="issuedBy">${escapeHtml(cert.provider || '')}</div>
                     </div>

--- a/public/shared/admin.js
+++ b/public/shared/admin.js
@@ -750,6 +750,7 @@ async function loadCertifications() {
     
     container.innerHTML = certs.map(cert => {
         const hasLogo = !!cert.logo_filename;
+        const hasLink = isValidUrl(cert.credential_id);
         return `
         <article class="cert-card ${cert.visible ? '' : 'hidden-print'}${hasLogo ? ' has-logo' : ''}" data-id="${cert.id}" draggable="true" itemscope itemtype="https://schema.org/EducationalOccupationalCredential">
             <div class="drag-handle" title="Drag to reorder">${dragHandleIcon()}</div>
@@ -766,7 +767,10 @@ async function loadCertifications() {
             </div>
             ${hasLogo ? `<img src="/uploads/${encodeURIComponent(cert.logo_filename)}" class="cert-logo" alt="${escapeHtml(cert.provider || '')}" onerror="this.style.display='none'">` : ''}
             <div class="cert-content">
-                <div class="cert-name" itemprop="name">${escapeHtml(cert.name)}</div>
+                <div class="cert-header">
+                    <div class="cert-name" itemprop="name">${escapeHtml(cert.name)}</div>
+                    ${hasLink ? `<a href="${escapeHtml(cert.credential_id)}" class="cert-link" target="_blank" rel="noopener" title="${t('view_credential')}">${linkIcon()}</a>` : ''}
+                </div>
                 <time class="cert-date" itemprop="dateCreated">${formatDate(cert.issue_date) || escapeHtml(cert.issue_date || '')}</time>
                 <div class="cert-provider" itemprop="issuedBy">${escapeHtml(cert.provider || '')}</div>
             </div>
@@ -1187,8 +1191,8 @@ function certificationForm(d) {
             </div>
         </div>
         <div class="form-group">
-            <label class="form-label">${t('form.credential_id')}</label>
-            <input type="text" class="form-input" id="f-credential_id" value="${escapeHtml(d.credential_id || '')}">
+            <label class="form-label">${t('form.credential_url')}</label>
+            <input type="url" class="form-input" id="f-credential_id" value="${escapeHtml(d.credential_id || '')}" placeholder="${t('form.credential_url_placeholder')}">
         </div>
     `;
 }
@@ -1417,12 +1421,19 @@ async function saveItem() {
             const certExpiry = normalizeDate(val('f-expiry_date'));
             if (certExpiry.error) { toast(certExpiry.error, 'error'); return; }
 
+            // Validate credential URL if provided
+            const certCredUrl = val('f-credential_id').trim();
+            if (certCredUrl && !isValidUrl(certCredUrl)) {
+                toast(t('toast.credential_url_invalid'), 'error');
+                return;
+            }
+
             data = {
                 name: val('f-name'),
                 provider: val('f-provider'),
                 issue_date: certIssue.value,
                 expiry_date: certExpiry.value,
-                credential_id: val('f-credential_id'),
+                credential_id: certCredUrl,
                 visible: true
             };
             {

--- a/public/shared/i18n/de.json
+++ b/public/shared/i18n/de.json
@@ -117,6 +117,8 @@
     "form.issue_date_placeholder": "Jan 2024",
     "form.expiry_date": "Ablaufdatum (optional)",
     "form.credential_id": "Nachweis-ID (optional)",
+    "form.credential_url": "Nachweis-URL (optional)",
+    "form.credential_url_placeholder": "https://example.com/verify/ABC123",
     "form.degree": "Abschluss / Qualifikation",
     "form.institution": "Bildungseinrichtung",
     "form.start_year": "Startjahr",
@@ -347,6 +349,7 @@
     "toast.item_deleted": "Eintrag gelöscht",
     "toast.item_delete_failed": "Eintrag konnte nicht gelöscht werden",
     "toast.failed_save": "Speichern fehlgeschlagen",
+    "toast.credential_url_invalid": "Nachweis-URL muss mit http:// oder https:// beginnen",
 
     "confirm.delete_item": "Sind Sie sicher, dass Sie diesen Eintrag löschen möchten?",
     "confirm.delete_dataset": "Datensatz \"{{name}}\" löschen? Dies kann nicht rückgängig gemacht werden.",
@@ -374,5 +377,6 @@
 
     "view_link": "Ansehen →",
     "learn_more": "Mehr erfahren →",
-    "view_project": "Projekt ansehen"
+    "view_project": "Projekt ansehen",
+    "view_credential": "Nachweis ansehen"
 }

--- a/public/shared/i18n/en.json
+++ b/public/shared/i18n/en.json
@@ -117,6 +117,8 @@
     "form.issue_date_placeholder": "Jan 2024",
     "form.expiry_date": "Expiry Date (optional)",
     "form.credential_id": "Credential ID (optional)",
+    "form.credential_url": "Credential URL (optional)",
+    "form.credential_url_placeholder": "https://example.com/verify/ABC123",
     "form.degree": "Degree / Qualification",
     "form.institution": "Institution",
     "form.start_year": "Start Year",
@@ -347,6 +349,7 @@
     "toast.item_deleted": "Item deleted",
     "toast.item_delete_failed": "Failed to delete item",
     "toast.failed_save": "Failed to save",
+    "toast.credential_url_invalid": "Credential URL must start with http:// or https://",
 
     "confirm.delete_item": "Are you sure you want to delete this item?",
     "confirm.delete_dataset": "Delete dataset \"{{name}}\"? This cannot be undone.",
@@ -373,5 +376,6 @@
     "items": "items",
     "view_link": "View →",
     "learn_more": "Learn More →",
-    "view_project": "View Project"
+    "view_project": "View Project",
+    "view_credential": "View Credential"
 }

--- a/public/shared/i18n/es.json
+++ b/public/shared/i18n/es.json
@@ -110,6 +110,8 @@
     "form.issue_date_placeholder": "Ene 2024",
     "form.expiry_date": "Fecha de vencimiento (opcional)",
     "form.credential_id": "ID de credencial (opcional)",
+    "form.credential_url": "URL de credencial (opcional)",
+    "form.credential_url_placeholder": "https://example.com/verify/ABC123",
     "form.degree": "Título / Cualificación",
     "form.institution": "Institución",
     "form.start_year": "Año de inicio",
@@ -330,6 +332,7 @@
     "toast.item_deleted": "Elemento eliminado",
     "toast.item_delete_failed": "Error al eliminar el elemento",
     "toast.failed_save": "Error al guardar",
+    "toast.credential_url_invalid": "La URL de credencial debe comenzar con http:// o https://",
     "confirm.delete_item": "¿Estás seguro de que deseas eliminar este elemento?",
     "confirm.delete_dataset": "¿Eliminar el conjunto de datos \"{{name}}\"? Esta acción no se puede deshacer.",
     "confirm.delete_section": "¿Eliminar esta sección personalizada y todos sus elementos? Esta acción no se puede deshacer.",
@@ -354,5 +357,6 @@
     "items": "elementos",
     "view_link": "Ver →",
     "learn_more": "Más información →",
-    "view_project": "Ver proyecto"
+    "view_project": "Ver proyecto",
+    "view_credential": "Ver credencial"
 }

--- a/public/shared/i18n/fr.json
+++ b/public/shared/i18n/fr.json
@@ -117,6 +117,8 @@
     "form.issue_date_placeholder": "Janv. 2024",
     "form.expiry_date": "Date d'expiration (facultatif)",
     "form.credential_id": "Identifiant du certificat (facultatif)",
+    "form.credential_url": "URL du certificat (facultatif)",
+    "form.credential_url_placeholder": "https://example.com/verify/ABC123",
     "form.degree": "Diplôme / Qualification",
     "form.institution": "Établissement",
     "form.start_year": "Année de début",
@@ -347,6 +349,7 @@
     "toast.item_deleted": "Élément supprimé",
     "toast.item_delete_failed": "Échec de la suppression de l'élément",
     "toast.failed_save": "Échec de l'enregistrement",
+    "toast.credential_url_invalid": "L'URL du certificat doit commencer par http:// ou https://",
 
     "confirm.delete_item": "Êtes-vous sûr de vouloir supprimer cet élément ?",
     "confirm.delete_dataset": "Supprimer le jeu de données « {{name}} » ? Cette action est irréversible.",
@@ -374,5 +377,6 @@
 
     "view_link": "Voir →",
     "learn_more": "En savoir plus →",
-    "view_project": "Voir le projet"
+    "view_project": "Voir le projet",
+    "view_credential": "Voir le certificat"
 }

--- a/public/shared/i18n/it.json
+++ b/public/shared/i18n/it.json
@@ -110,6 +110,8 @@
     "form.issue_date_placeholder": "Gen 2024",
     "form.expiry_date": "Data di scadenza (opzionale)",
     "form.credential_id": "ID credenziale (opzionale)",
+    "form.credential_url": "URL credenziale (opzionale)",
+    "form.credential_url_placeholder": "https://example.com/verify/ABC123",
     "form.degree": "Titolo di studio / Qualifica",
     "form.institution": "Istituto",
     "form.start_year": "Anno di inizio",
@@ -330,6 +332,7 @@
     "toast.item_deleted": "Elemento eliminato",
     "toast.item_delete_failed": "Eliminazione elemento fallita",
     "toast.failed_save": "Salvataggio fallito",
+    "toast.credential_url_invalid": "L'URL della credenziale deve iniziare con http:// o https://",
     "confirm.delete_item": "Sei sicuro di voler eliminare questo elemento?",
     "confirm.delete_dataset": "Eliminare il dataset \"{{name}}\"? Questa azione non può essere annullata.",
     "confirm.delete_section": "Eliminare questa sezione personalizzata e tutti i suoi elementi? Questa azione non può essere annullata.",
@@ -354,5 +357,6 @@
     "items": "elementi",
     "view_link": "Vedi →",
     "learn_more": "Scopri di più →",
-    "view_project": "Vedi progetto"
+    "view_project": "Vedi progetto",
+    "view_credential": "Vedi credenziale"
 }

--- a/public/shared/i18n/nl.json
+++ b/public/shared/i18n/nl.json
@@ -110,6 +110,8 @@
     "form.issue_date_placeholder": "Jan 2024",
     "form.expiry_date": "Vervaldatum (optioneel)",
     "form.credential_id": "Referentienummer (optioneel)",
+    "form.credential_url": "Referentie-URL (optioneel)",
+    "form.credential_url_placeholder": "https://example.com/verify/ABC123",
     "form.degree": "Diploma / Kwalificatie",
     "form.institution": "Instelling",
     "form.start_year": "Startjaar",
@@ -330,6 +332,7 @@
     "toast.item_deleted": "Item verwijderd",
     "toast.item_delete_failed": "Verwijderen van item mislukt",
     "toast.failed_save": "Opslaan mislukt",
+    "toast.credential_url_invalid": "Referentie-URL moet beginnen met http:// of https://",
     "confirm.delete_item": "Weet je zeker dat je dit item wilt verwijderen?",
     "confirm.delete_dataset": "Dataset \"{{name}}\" verwijderen? Dit kan niet ongedaan worden gemaakt.",
     "confirm.delete_section": "Deze aangepaste sectie en alle items verwijderen? Dit kan niet ongedaan worden gemaakt.",
@@ -354,5 +357,6 @@
     "items": "items",
     "view_link": "Bekijken →",
     "learn_more": "Meer informatie →",
-    "view_project": "Project bekijken"
+    "view_project": "Project bekijken",
+    "view_credential": "Referentie bekijken"
 }

--- a/public/shared/i18n/pt.json
+++ b/public/shared/i18n/pt.json
@@ -110,6 +110,8 @@
     "form.issue_date_placeholder": "Jan 2024",
     "form.expiry_date": "Data de Validade (opcional)",
     "form.credential_id": "ID da Credencial (opcional)",
+    "form.credential_url": "URL da Credencial (opcional)",
+    "form.credential_url_placeholder": "https://example.com/verify/ABC123",
     "form.degree": "Grau / Qualificação",
     "form.institution": "Instituição",
     "form.start_year": "Ano de Início",
@@ -330,6 +332,7 @@
     "toast.item_deleted": "Item eliminado",
     "toast.item_delete_failed": "Falha ao eliminar o item",
     "toast.failed_save": "Falha ao guardar",
+    "toast.credential_url_invalid": "O URL da credencial deve começar com http:// ou https://",
     "confirm.delete_item": "Tem a certeza de que deseja eliminar este item?",
     "confirm.delete_dataset": "Eliminar o conjunto de dados \"{{name}}\"? Esta ação não pode ser revertida.",
     "confirm.delete_section": "Eliminar esta secção personalizada e todos os seus itens? Esta ação não pode ser revertida.",
@@ -354,5 +357,6 @@
     "items": "itens",
     "view_link": "Ver →",
     "learn_more": "Saiba mais →",
-    "view_project": "Ver projeto"
+    "view_project": "Ver projeto",
+    "view_credential": "Ver credencial"
 }

--- a/public/shared/i18n/zh.json
+++ b/public/shared/i18n/zh.json
@@ -110,6 +110,8 @@
     "form.issue_date_placeholder": "2024年1月",
     "form.expiry_date": "到期日期（可选）",
     "form.credential_id": "证书编号（可选）",
+    "form.credential_url": "证书链接（可选）",
+    "form.credential_url_placeholder": "https://example.com/verify/ABC123",
     "form.degree": "学位 / 学历",
     "form.institution": "院校",
     "form.start_year": "入学年份",
@@ -330,6 +332,7 @@
     "toast.item_deleted": "条目已删除",
     "toast.item_delete_failed": "删除条目失败",
     "toast.failed_save": "保存失败",
+    "toast.credential_url_invalid": "证书链接必须以 http:// 或 https:// 开头",
     "confirm.delete_item": "确定要删除此条目吗？",
     "confirm.delete_dataset": "删除数据集「{{name}}」？此操作无法撤销。",
     "confirm.delete_section": "删除此自定义板块及其所有条目？此操作无法撤销。",
@@ -353,5 +356,6 @@
     "items": "条目",
     "view_link": "查看 →",
     "learn_more": "了解更多 →",
-    "view_project": "查看项目"
+    "view_project": "查看项目",
+    "view_credential": "查看证书"
 }

--- a/public/shared/scripts.js
+++ b/public/shared/scripts.js
@@ -108,6 +108,17 @@ function escapeHtml(text) {
     return div.innerHTML;
 }
 
+// Validate that a string is an http(s) URL. Used for optional URL fields.
+function isValidUrl(v) {
+    if (!v) return false;
+    try {
+        const u = new URL(v);
+        return u.protocol === 'http:' || u.protocol === 'https:';
+    } catch {
+        return false;
+    }
+}
+
 // Global date format setting - loaded from settings API
 let dateFormatSetting = 'MMM YYYY'; // default: "Jan 2020"
 let timelineYearOnly = true; // default: show years only in timeline
@@ -1161,11 +1172,15 @@ async function loadCertificationsReadOnly() {
     
     container.innerHTML = certs.map(cert => {
         const hasLogo = !!cert.logo_filename;
+        const hasLink = isValidUrl(cert.credential_id);
         return `
         <article class="cert-card${hasLogo ? ' has-logo' : ''}" itemscope itemtype="https://schema.org/EducationalOccupationalCredential">
             ${hasLogo ? `<img src="/uploads/${encodeURIComponent(cert.logo_filename)}" class="cert-logo" alt="${escapeHtml(cert.provider || '')}" onerror="this.style.display='none'">` : ''}
             <div class="cert-content">
-                <div class="cert-name" itemprop="name">${escapeHtml(cert.name)}</div>
+                <div class="cert-header">
+                    <div class="cert-name" itemprop="name">${escapeHtml(cert.name)}</div>
+                    ${hasLink ? `<a href="${escapeHtml(cert.credential_id)}" class="cert-link" target="_blank" rel="noopener" itemprop="url" title="${t('view_credential')}">${icons.link}</a>` : ''}
+                </div>
                 <time class="cert-date" itemprop="dateCreated">${formatDate(cert.issue_date) || escapeHtml(cert.issue_date || '')}</time>
                 <div class="cert-provider" itemprop="issuedBy">${escapeHtml(cert.provider || '')}</div>
             </div>

--- a/public/shared/styles.css
+++ b/public/shared/styles.css
@@ -526,10 +526,43 @@ body {
     min-width: 0;
 }
 
+.cert-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 6px;
+}
+
 .cert-name {
     font-size: 13px;
     font-weight: 600;
     color: var(--primary-dark);
+    flex: 1;
+    min-width: 0;
+}
+
+.cert-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: var(--radius-sm);
+    background: var(--light);
+    color: var(--primary);
+    transition: all 0.15s ease;
+    flex-shrink: 0;
+}
+
+.cert-link:hover {
+    background: var(--primary);
+    color: var(--white);
+}
+
+.cert-link svg, .cert-link .material-symbols-outlined {
+    width: 12px;
+    height: 12px;
+    font-size: 12px;
 }
 
 .cert-date {
@@ -1334,6 +1367,9 @@ body.has-preview-banner .container {
     .cert-card.has-logo { gap: 6px; }
     .cert-logo { width: 24px; height: 24px; }
     .cert-name { font-size: 11px; }
+    .cert-link { width: 16px; height: 16px; }
+    .cert-link svg { width: 9px; height: 9px; }
+    .cert-link .material-symbols-outlined { font-size: 9px; }
     .cert-date { font-size: 9px; }
     .cert-provider { font-size: 10px; }
     

--- a/public/shared/styles.css
+++ b/public/shared/styles.css
@@ -550,6 +550,7 @@ body {
     border-radius: var(--radius-sm);
     background: var(--light);
     color: var(--primary);
+    text-decoration: none;
     transition: all 0.15s ease;
     flex-shrink: 0;
 }
@@ -1367,9 +1368,7 @@ body.has-preview-banner .container {
     .cert-card.has-logo { gap: 6px; }
     .cert-logo { width: 24px; height: 24px; }
     .cert-name { font-size: 11px; }
-    .cert-link { width: 16px; height: 16px; }
-    .cert-link svg { width: 9px; height: 9px; }
-    .cert-link .material-symbols-outlined { font-size: 9px; }
+    .cert-link { display: none; }
     .cert-date { font-size: 9px; }
     .cert-provider { font-size: 10px; }
     

--- a/src/server.js
+++ b/src/server.js
@@ -52,6 +52,17 @@ function compareVersions(a, b) {
     return 0;
 }
 
+// Validate that a string is an http(s) URL. Empty/null values pass (optional fields).
+function isValidHttpUrl(v) {
+    if (v === null || v === undefined || v === '') return true;
+    try {
+        const u = new URL(v);
+        return u.protocol === 'http:' || u.protocol === 'https:';
+    } catch {
+        return false;
+    }
+}
+
 const DB_PATH = process.env.DB_PATH 
     ? path.resolve(process.env.DB_PATH)
     : path.join(__dirname, '..', 'data', 'cv.db');
@@ -933,7 +944,7 @@ if (PUBLIC_ONLY) {
     publicApp.get('/api/settings', (req, res) => { const settings = db.prepare('SELECT * FROM settings').all(); const result = {}; settings.forEach(s => { result[s.key] = s.value; }); res.json(result); });
     publicApp.get('/api/settings/:key', (req, res) => { const setting = db.prepare('SELECT value FROM settings WHERE key = ?').get(req.params.key); res.json({ value: setting?.value || null }); });
     publicApp.get('/api/experiences', (req, res) => { const experiences = db.prepare('SELECT id, job_title, company_name, start_date, end_date, location, country_code, highlights, summary, logo_filename FROM experiences WHERE visible = 1 ORDER BY sort_order ASC, start_date DESC').all(); res.json(experiences.map(e => ({ ...e, highlights: e.highlights ? JSON.parse(e.highlights) : [], visible: true }))); });
-    publicApp.get('/api/certifications', (req, res) => { res.json(db.prepare('SELECT name, provider, issue_date, expiry_date, logo_filename FROM certifications WHERE visible = 1 ORDER BY sort_order ASC, issue_date DESC').all().map(c => ({ ...c, visible: true }))); });
+    publicApp.get('/api/certifications', (req, res) => { res.json(db.prepare('SELECT name, provider, issue_date, expiry_date, credential_id, logo_filename FROM certifications WHERE visible = 1 ORDER BY sort_order ASC, issue_date DESC').all().map(c => ({ ...c, visible: true }))); });
     publicApp.get('/api/education', (req, res) => { res.json(db.prepare('SELECT degree_title, institution_name, start_date, end_date, description FROM education WHERE visible = 1 ORDER BY sort_order ASC, end_date DESC').all().map(e => ({ ...e, visible: true }))); });
     publicApp.get('/api/skills', (req, res) => { const categories = db.prepare('SELECT id, name, icon FROM skill_categories WHERE visible = 1 ORDER BY sort_order ASC').all(); const skills = db.prepare('SELECT * FROM skills ORDER BY sort_order ASC').all(); res.json(categories.map(cat => ({ ...cat, visible: true, skills: skills.filter(s => s.category_id === cat.id).map(s => s.name) }))); });
     publicApp.get('/api/projects', (req, res) => { res.json(db.prepare('SELECT title, description, technologies, link FROM projects WHERE visible = 1 ORDER BY sort_order ASC').all().map(p => ({ ...p, technologies: p.technologies ? JSON.parse(p.technologies) : [], visible: true }))); });
@@ -960,7 +971,7 @@ if (PUBLIC_ONLY) {
     publicApp.get('/api/cv', (req, res) => {
         const profile = db.prepare('SELECT name, initials, title, subtitle, bio, location, linkedin, languages, open_to_work FROM profile WHERE id = 1').get();
         const experiences = db.prepare('SELECT job_title, company_name, start_date, end_date, location, country_code, highlights, summary, logo_filename FROM experiences WHERE visible = 1 ORDER BY sort_order ASC, start_date DESC').all();
-        const certifications = db.prepare('SELECT name, provider, issue_date, expiry_date, logo_filename FROM certifications WHERE visible = 1 ORDER BY sort_order ASC, issue_date DESC').all();
+        const certifications = db.prepare('SELECT name, provider, issue_date, expiry_date, credential_id, logo_filename FROM certifications WHERE visible = 1 ORDER BY sort_order ASC, issue_date DESC').all();
         const education = db.prepare('SELECT degree_title, institution_name, start_date, end_date, description, logo_filename FROM education WHERE visible = 1 ORDER BY sort_order ASC, end_date DESC').all();
         const skillCategories = db.prepare('SELECT id, name, icon FROM skill_categories WHERE visible = 1 ORDER BY sort_order ASC').all();
         const skills = db.prepare('SELECT * FROM skills ORDER BY sort_order ASC').all();
@@ -1290,8 +1301,8 @@ if (PUBLIC_ONLY) {
 
     app.get('/api/certifications', (req, res) => { res.json(db.prepare('SELECT * FROM certifications ORDER BY sort_order ASC, issue_date DESC').all().map(c => ({ ...c, visible: !!c.visible }))); });
     app.get('/api/certifications/:id', (req, res) => { const cert = db.prepare('SELECT * FROM certifications WHERE id = ?').get(req.params.id); if (!cert) return res.status(404).json({ error: 'Not found' }); res.json({ ...cert, visible: !!cert.visible }); });
-    app.post('/api/certifications', (req, res) => { const { name, provider, issue_date, expiry_date, credential_id } = req.body; const maxOrder = db.prepare('SELECT MAX(sort_order) as max FROM certifications').get(); const result = db.prepare(`INSERT INTO certifications (name, provider, issue_date, expiry_date, credential_id, sort_order) VALUES (?, ?, ?, ?, ?, ?)`).run(name, provider, issue_date, expiry_date, credential_id, (maxOrder.max || 0) + 1); res.json({ id: result.lastInsertRowid }); });
-    app.put('/api/certifications/:id', (req, res) => { const { name, provider, issue_date, expiry_date, credential_id, visible, sort_order } = req.body; const existing = db.prepare('SELECT sort_order, visible FROM certifications WHERE id = ?').get(req.params.id); const newSortOrder = sort_order !== undefined ? sort_order : (existing?.sort_order || 0); const newVisible = visible !== undefined ? (visible ? 1 : 0) : (existing?.visible ?? 1); db.prepare(`UPDATE certifications SET name = ?, provider = ?, issue_date = ?, expiry_date = ?, credential_id = ?, visible = ?, sort_order = ? WHERE id = ?`).run(name, provider, issue_date, expiry_date, credential_id, newVisible, newSortOrder, req.params.id); res.json({ success: true }); });
+    app.post('/api/certifications', (req, res) => { const { name, provider, issue_date, expiry_date, credential_id } = req.body; if (!isValidHttpUrl(credential_id)) return res.status(400).json({ error: 'credential_id must be a valid http(s) URL' }); const maxOrder = db.prepare('SELECT MAX(sort_order) as max FROM certifications').get(); const result = db.prepare(`INSERT INTO certifications (name, provider, issue_date, expiry_date, credential_id, sort_order) VALUES (?, ?, ?, ?, ?, ?)`).run(name, provider, issue_date, expiry_date, credential_id, (maxOrder.max || 0) + 1); res.json({ id: result.lastInsertRowid }); });
+    app.put('/api/certifications/:id', (req, res) => { const { name, provider, issue_date, expiry_date, credential_id, visible, sort_order } = req.body; if (!isValidHttpUrl(credential_id)) return res.status(400).json({ error: 'credential_id must be a valid http(s) URL' }); const existing = db.prepare('SELECT sort_order, visible FROM certifications WHERE id = ?').get(req.params.id); const newSortOrder = sort_order !== undefined ? sort_order : (existing?.sort_order || 0); const newVisible = visible !== undefined ? (visible ? 1 : 0) : (existing?.visible ?? 1); db.prepare(`UPDATE certifications SET name = ?, provider = ?, issue_date = ?, expiry_date = ?, credential_id = ?, visible = ?, sort_order = ? WHERE id = ?`).run(name, provider, issue_date, expiry_date, credential_id, newVisible, newSortOrder, req.params.id); res.json({ success: true }); });
     app.delete('/api/certifications/:id', (req, res) => { const cert = db.prepare('SELECT logo_filename FROM certifications WHERE id = ?').get(req.params.id); if (cert && cert.logo_filename) { const refCountExp = db.prepare('SELECT COUNT(*) as cnt FROM experiences WHERE logo_filename = ?').get(cert.logo_filename).cnt; const refCountEdu = db.prepare('SELECT COUNT(*) as cnt FROM education WHERE logo_filename = ?').get(cert.logo_filename).cnt; const refCountCert = db.prepare('SELECT COUNT(*) as cnt FROM certifications WHERE logo_filename = ?').get(cert.logo_filename).cnt; if (refCountExp + refCountEdu + refCountCert <= 1) { const logoPath = path.join(uploadsPath, cert.logo_filename); try { if (fs.existsSync(logoPath)) fs.unlinkSync(logoPath); } catch (e) {} } } db.prepare('DELETE FROM certifications WHERE id = ?').run(req.params.id); res.json({ success: true }); });
 
     // Certification logo upload
@@ -2261,12 +2272,8 @@ if (PUBLIC_ONLY) {
             delete profile.id;
             delete profile.updated_at;
 
-            // Filter sensitive data from certifications
-            const certifications = cvData.certifications.map(c => {
-                const clean = { ...c };
-                delete clean.credential_id;
-                return clean;
-            });
+            // Certifications: credential_id is a public verification URL, no filtering needed
+            const certifications = cvData.certifications;
 
             // Gather all settings
             const settingsRows = db.prepare('SELECT * FROM settings').all();
@@ -2473,7 +2480,7 @@ if (PUBLIC_ONLY) {
     publicApp.get('/api/settings', (req, res) => { const settings = db.prepare('SELECT * FROM settings').all(); const result = {}; settings.forEach(s => { result[s.key] = s.value; }); res.json(result); });
     publicApp.get('/api/settings/:key', (req, res) => { const setting = db.prepare('SELECT value FROM settings WHERE key = ?').get(req.params.key); res.json({ value: setting?.value || null }); });
     publicApp.get('/api/experiences', (req, res) => { res.json(db.prepare('SELECT job_title, company_name, start_date, end_date, location, country_code, highlights, logo_filename FROM experiences WHERE visible = 1 ORDER BY sort_order ASC, start_date DESC').all().map(e => ({ ...e, highlights: e.highlights ? JSON.parse(e.highlights) : [], visible: true }))); });
-    publicApp.get('/api/certifications', (req, res) => { res.json(db.prepare('SELECT name, provider, issue_date, expiry_date, logo_filename FROM certifications WHERE visible = 1 ORDER BY sort_order ASC, issue_date DESC').all().map(c => ({ ...c, visible: true }))); });
+    publicApp.get('/api/certifications', (req, res) => { res.json(db.prepare('SELECT name, provider, issue_date, expiry_date, credential_id, logo_filename FROM certifications WHERE visible = 1 ORDER BY sort_order ASC, issue_date DESC').all().map(c => ({ ...c, visible: true }))); });
     publicApp.get('/api/education', (req, res) => { res.json(db.prepare('SELECT degree_title, institution_name, start_date, end_date, description FROM education WHERE visible = 1 ORDER BY sort_order ASC, end_date DESC').all().map(e => ({ ...e, visible: true }))); });
     publicApp.get('/api/skills', (req, res) => { const categories = db.prepare('SELECT id, name, icon FROM skill_categories WHERE visible = 1 ORDER BY sort_order ASC').all(); const skills = db.prepare('SELECT * FROM skills ORDER BY sort_order ASC').all(); res.json(categories.map(cat => ({ ...cat, visible: true, skills: skills.filter(s => s.category_id === cat.id).map(s => s.name) }))); });
     publicApp.get('/api/projects', (req, res) => { res.json(db.prepare('SELECT title, description, technologies, link FROM projects WHERE visible = 1 ORDER BY sort_order ASC').all().map(p => ({ ...p, technologies: p.technologies ? JSON.parse(p.technologies) : [], visible: true }))); });
@@ -2497,7 +2504,7 @@ if (PUBLIC_ONLY) {
     });
     publicApp.get('/api/layout-types', (req, res) => { res.json(LAYOUT_TYPES); });
     publicApp.get('/api/social-platforms', (req, res) => { res.json(SOCIAL_PLATFORMS); });
-    publicApp.get('/api/cv', (req, res) => { const profile = db.prepare('SELECT name, initials, title, subtitle, bio, location, linkedin, languages, open_to_work FROM profile WHERE id = 1').get(); const experiences = db.prepare('SELECT job_title, company_name, start_date, end_date, location, country_code, highlights, logo_filename FROM experiences WHERE visible = 1 ORDER BY sort_order ASC, start_date DESC').all(); const certifications = db.prepare('SELECT name, provider, issue_date, expiry_date, logo_filename FROM certifications WHERE visible = 1 ORDER BY sort_order ASC, issue_date DESC').all(); const education = db.prepare('SELECT degree_title, institution_name, start_date, end_date, description, logo_filename FROM education WHERE visible = 1 ORDER BY sort_order ASC, end_date DESC').all(); const skillCategories = db.prepare('SELECT id, name, icon FROM skill_categories WHERE visible = 1 ORDER BY sort_order ASC').all(); const skills = db.prepare('SELECT * FROM skills ORDER BY sort_order ASC').all(); const projects = db.prepare('SELECT title, description, technologies, link FROM projects WHERE visible = 1 ORDER BY sort_order ASC').all(); const sectionOrder = db.prepare('SELECT section_name, sort_order FROM section_visibility WHERE visible = 1 ORDER BY sort_order ASC').all(); res.json({ profile, experiences: experiences.map(e => ({ ...e, highlights: e.highlights ? JSON.parse(e.highlights) : [] })), certifications, education, skills: skillCategories.map(cat => ({ ...cat, skills: skills.filter(s => s.category_id === cat.id).map(s => s.name) })), projects: projects.map(p => ({ ...p, technologies: p.technologies ? JSON.parse(p.technologies) : [] })), sectionOrder: sectionOrder.map(s => s.section_name) }); });
+    publicApp.get('/api/cv', (req, res) => { const profile = db.prepare('SELECT name, initials, title, subtitle, bio, location, linkedin, languages, open_to_work FROM profile WHERE id = 1').get(); const experiences = db.prepare('SELECT job_title, company_name, start_date, end_date, location, country_code, highlights, logo_filename FROM experiences WHERE visible = 1 ORDER BY sort_order ASC, start_date DESC').all(); const certifications = db.prepare('SELECT name, provider, issue_date, expiry_date, credential_id, logo_filename FROM certifications WHERE visible = 1 ORDER BY sort_order ASC, issue_date DESC').all(); const education = db.prepare('SELECT degree_title, institution_name, start_date, end_date, description, logo_filename FROM education WHERE visible = 1 ORDER BY sort_order ASC, end_date DESC').all(); const skillCategories = db.prepare('SELECT id, name, icon FROM skill_categories WHERE visible = 1 ORDER BY sort_order ASC').all(); const skills = db.prepare('SELECT * FROM skills ORDER BY sort_order ASC').all(); const projects = db.prepare('SELECT title, description, technologies, link FROM projects WHERE visible = 1 ORDER BY sort_order ASC').all(); const sectionOrder = db.prepare('SELECT section_name, sort_order FROM section_visibility WHERE visible = 1 ORDER BY sort_order ASC').all(); res.json({ profile, experiences: experiences.map(e => ({ ...e, highlights: e.highlights ? JSON.parse(e.highlights) : [] })), certifications, education, skills: skillCategories.map(cat => ({ ...cat, skills: skills.filter(s => s.category_id === cat.id).map(s => s.name) })), projects: projects.map(p => ({ ...p, technologies: p.technologies ? JSON.parse(p.technologies) : [] })), sectionOrder: sectionOrder.map(s => s.section_name) }); });
     // Public versioned CV routes
     publicApp.get('/v/:slug', (req, res) => { serveDatasetPage(req, res); });
     publicApp.get('/api/datasets/slug/:slug', (req, res) => { serveDatasetData(req, res); });

--- a/tests/backend.test.js
+++ b/tests/backend.test.js
@@ -233,7 +233,39 @@ describe('Backend API', () => {
                     provider: 'Amazon',
                     issue_date: '2024-01',
                     expiry_date: '2027-01',
-                    credential_id: 'AWS-123',
+                    credential_id: 'https://aws.amazon.com/verification/AWS-123',
+                }),
+            });
+            assert.strictEqual(res.status, 200);
+            const data = await res.json();
+            assert.ok(data.id);
+        });
+
+        it('POST /api/certifications rejects a non-URL credential_id', async () => {
+            const res = await fetch(`${BASE_URL}/api/certifications`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    name: 'BadCert',
+                    provider: 'X',
+                    issue_date: '2024-01',
+                    credential_id: 'not-a-url',
+                }),
+            });
+            assert.strictEqual(res.status, 400);
+            const data = await res.json();
+            assert.match(data.error, /URL/i);
+        });
+
+        it('POST /api/certifications accepts empty credential_id', async () => {
+            const res = await fetch(`${BASE_URL}/api/certifications`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    name: 'NoCredCert',
+                    provider: 'X',
+                    issue_date: '2024-01',
+                    credential_id: '',
                 }),
             });
             assert.strictEqual(res.status, 200);
@@ -268,7 +300,7 @@ describe('Backend API', () => {
             const res = await fetch(`${BASE_URL}/api/certifications/${id}`, {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ name: 'UpdatedCert', provider: 'NewProvider', issue_date: '2024-06', expiry_date: '2027-06', credential_id: 'NEW-456' }),
+                body: JSON.stringify({ name: 'UpdatedCert', provider: 'NewProvider', issue_date: '2024-06', expiry_date: '2027-06', credential_id: 'https://aws.amazon.com/verification/NEW-456' }),
             });
             assert.strictEqual(res.status, 200);
 
@@ -854,6 +886,30 @@ describe('Backend API', () => {
             assert.strictEqual(res.status, 200);
             const data = await res.json();
             assert.ok(Array.isArray(data));
+        });
+
+        it('GET /api/certifications exposes credential_id as URL', async () => {
+            // Create a cert via admin API with a credential URL
+            const credUrl = 'https://www.credly.com/badges/example/public-api-test';
+            const createRes = await fetch(`${BASE_URL}/api/certifications`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    name: 'PublicApiCert',
+                    provider: 'TestProv',
+                    issue_date: '2024-01',
+                    credential_id: credUrl,
+                }),
+            });
+            assert.strictEqual(createRes.status, 200);
+
+            const res = await fetch(`${PUBLIC_URL}/api/certifications`);
+            assert.strictEqual(res.status, 200);
+            const data = await res.json();
+            assert.ok(Array.isArray(data));
+            const cert = data.find(c => c.name === 'PublicApiCert');
+            assert.ok(cert, 'Created cert should appear in public API');
+            assert.strictEqual(cert.credential_id, credUrl, 'Public API should expose credential_id');
         });
 
         it('GET /api/cv returns full CV object', async () => {

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.26.4",
+  "version": "1.26.5",
   "changelog": "https://github.com/vincentmakes/cv-manager/blob/main/CHANGELOG.md"
 }

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.26.3",
+  "version": "1.26.4",
   "changelog": "https://github.com/vincentmakes/cv-manager/blob/main/CHANGELOG.md"
 }


### PR DESCRIPTION
## Description

This PR enhances the certifications feature to properly handle credential URLs as clickable links, matching the behavior of the Projects section. The `credential_id` field is now validated as an HTTP(S) URL on both client and server, rendered with a link icon in both admin and public views, and exposed in the public API.

### Key Changes

- **Server-side validation**: Added `isValidHttpUrl()` function to validate credential URLs (http/https only). Empty values are allowed for optional fields.
- **Client-side validation**: Added `isValidUrl()` function in `scripts.js` for consistent validation across the UI.
- **API changes**: 
  - POST/PUT `/api/certifications` now validates `credential_id` and returns 400 if invalid
  - GET `/api/certifications` now includes `credential_id` in the public API response (previously stripped)
- **UI improvements**:
  - Credential URLs now render as clickable link icons (opens in new tab) in both admin and public views
  - New `.cert-header` layout with flexbox to accommodate the link icon alongside the cert name
  - Form field renamed from "Credential ID" to "Credential URL" with URL input type and placeholder
  - Responsive styling for mobile (smaller icon sizes)
- **Internationalization**: Updated all 8 locale files with new keys:
  - `form.credential_url` and `form.credential_url_placeholder`
  - `toast.credential_url_invalid`
  - `view_credential`
- **Demo data**: Updated sample `credential_id` values to realistic verification URLs (Credly, Microsoft Learn, etc.)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

### Required for all code changes

- [x] I have tested my changes locally (`npm test` passes)
- [x] Version has been bumped in all 3 files (`package.json`, `package-lock.json`, `version.json`)
- [x] `CHANGELOG.md` has been updated with a new entry under the correct version

### If adding or changing user-visible strings

- [x] No hardcoded English — all strings use `t('key')` in JS or `data-i18n` in HTML
- [x] New i18n keys added to `en.json` and all 7 other locale files (`de`, `fr`, `nl`, `es`, `it`, `pt`, `zh`)
- [x] `escapeHtml()` used for any user-provided content rendered as HTML

## Test Coverage

The changes include comprehensive test coverage:
- Test for valid credential URL acceptance (POST `/api/certifications`)
- Test for invalid credential URL rejection with 400 status
- Test for empty credential URL acceptance
- Test for credential URL exposure in public API
- Test for credential URL updates via PUT endpoint
- Existing tests updated to use valid URLs in test data

https://claude.ai/code/session_01APUFWc5DL8X7PmM93zimVM