### PR TITLE
Reorder overlay: stop placeholder animating up from zero on insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to CV Manager will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/), versioning follows [Semantic Versioning](https://semver.org/).
 
+## [1.37.1] - 2026-04-18
+
+### Fixed
+- Section reorder overlay: the dashed placeholder renders at its full height the moment a drag starts instead of animating up from zero, so it matches the height of the floating pill again. A stale `transition: height .2s ease` on `.reorder-placeholder` was firing on insertion (the placeholder is created detached with its target height set inline, then inserted into the list), making the placeholder visibly grow over 200 ms every time a drag began. The transition served no purpose since the placeholder's height is set once at creation and never changes.
+
 ## [1.37.0] - 2026-04-18
 
 ### Removed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cv-manager",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cv-manager",
-      "version": "1.37.0",
+      "version": "1.37.1",
       "dependencies": {
         "archiver": "^7.0.1",
         "better-sqlite3": "^9.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cv-manager",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "description": "Professional CV Management System",
   "main": "src/server.js",
   "scripts": {

--- a/public/shared/admin.css
+++ b/public/shared/admin.css
@@ -2899,7 +2899,6 @@ body.reorder-active .section-reorder-handle { opacity: 0; pointer-events: none; 
     border: 2px dashed rgba(255, 255, 255, 0.45);
     border-radius: var(--radius-lg);
     background: rgba(255, 255, 255, 0.08);
-    transition: height .2s ease;
 }
 
 .reorder-footer {

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.37.0",
+  "version": "1.37.1",
   "changelog": "https://github.com/vincentmakes/cv-manager/blob/main/CHANGELOG.md"
 }


### PR DESCRIPTION
The dashed .reorder-placeholder carried `transition: height .2s ease`,
so every time a drag started the placeholder (created detached with its
target height set inline, then inserted into the list) animated up from
~0 to its full height over 200 ms. The floating pill, which doesn't
transition, appeared at full height immediately — making the placeholder
visibly shorter than the pill during the drag.

The transition was dead code: the placeholder's height is set once at
creation (admin.js:5065) and never written again. Dropping the transition
makes the placeholder render at full height instantly, matching the pill.

https://claude.ai/code/session_01TZA17yUsrhNLFMW39M87gF