### PR TITLE
Fix timeline section hiding in print output on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to CV Manager will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/), versioning follows [Semantic Versioning](https://semver.org/).
 
+## [1.41.1] - 2026-04-19
+
+### Fixed
+- Hiding the timeline section (via the section-visibility toggle, `.is-hidden`) now correctly omits it from printed output instead of printing it as a faded, dashed-border block. The mobile-width print override — which re-enables the timeline in print to counteract the `@media (max-width: 768px)` mobile hide — used `#section-timeline:not(.hidden-print)` and had higher CSS specificity than the generic `.is-hidden { display: none !important; }` rule, so the override won in print and the dimmed `.is-hidden` box still printed. The override now also excludes `.is-hidden`, so genuinely hidden timelines are absent from print output on every viewport width. Hiding non-timeline sections was already correct; this bug was specific to the timeline because it is the only section with a mobile-print re-enable rule.
+
 ## [1.41.0] - 2026-04-19
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cv-manager",
-  "version": "1.41.0",
+  "version": "1.41.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cv-manager",
-      "version": "1.41.0",
+      "version": "1.41.1",
       "dependencies": {
         "archiver": "^7.0.1",
         "better-sqlite3": "^9.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cv-manager",
-  "version": "1.41.0",
+  "version": "1.41.1",
   "description": "Professional CV Management System",
   "main": "src/server.js",
   "scripts": {

--- a/public/shared/styles.css
+++ b/public/shared/styles.css
@@ -2003,8 +2003,8 @@ body.has-preview-banner .container {
 
 /* Mobile print - show timeline again (only if not hidden by user choice) */
 @media print {
-    #section-timeline:not(.hidden-print) { display: block !important; }
-    #section-timeline:not(.hidden-print) .timeline-container { display: block !important; }
+    #section-timeline:not(.hidden-print):not(.is-hidden) { display: block !important; }
+    #section-timeline:not(.hidden-print):not(.is-hidden) .timeline-container { display: block !important; }
 }
 
 /* Print pagination is handled via JavaScript-injected @page rules */

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.41.0",
+  "version": "1.41.1",
   "changelog": "https://github.com/vincentmakes/cv-manager/blob/main/CHANGELOG.md"
 }


### PR DESCRIPTION
## Description

Fixes a CSS specificity bug where hiding the timeline section via the section-visibility toggle (`.is-hidden` class) was not being respected in print output on mobile viewports. The timeline would still appear as a faded, dashed-border block instead of being completely omitted.

The root cause was that the mobile print override rule `#section-timeline:not(.hidden-print)` had higher specificity than the generic `.is-hidden { display: none !important; }` rule, causing the override to win and re-enable the timeline even when the user had hidden it.

The fix adds `:not(.is-hidden)` to both mobile print override selectors, ensuring that genuinely hidden timelines are absent from print output on all viewport widths. Hiding non-timeline sections was already working correctly; this bug was specific to the timeline because it's the only section with a mobile-print re-enable rule.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (changes to docs only — no version bump needed)
- [ ] Translation (new or updated language files)
- [ ] Refactoring (no functional changes)

## Checklist

### Required for all code changes

- [x] I have tested my changes locally (`npm test` passes)
- [x] Version has been bumped in all 3 files (`package.json`, `package-lock.json`, `version.json`)
- [x] `CHANGELOG.md` has been updated with a new entry under the correct version

### If adding or changing user-visible strings

- [x] N/A — no user-visible strings changed

### If documentation-only change

- [x] N/A — not a documentation-only change

https://claude.ai/code/session_01NjtKez7wnZgJrBfDnioPrw