### PR TITLE
Apply profile-picture crop on the dataset-snapshot render path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to CV Manager will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/), versioning follows [Semantic Versioning](https://semver.org/).
 
+## [1.47.2] - 2026-04-21
+
+### Fixed
+- **Profile-picture crop was not reflected on the public site when a default dataset existed.** The public page has two render paths: the live-profile path goes through `scripts.js`'s shared `loadProfile` (which was already updated to apply the crop), but when a default dataset is configured the page instead calls `loadDatasetPreview` → `renderProfileFromData` — a separate inline copy of the render logic in `public-readonly/index.html` that had no knowledge of `picture_crop`. Added the `applyProfilePictureCrop(pic, p.picture_crop)` call alongside the `pic.src` assignment in `renderProfileFromData` so the crop is applied on the dataset-snapshot render path too. Snapshots created before 1.47.0 have no `picture_crop` field and render at the neutral default, so there's no visual regression for existing installs.
+
 ## [1.47.1] - 2026-04-21
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cv-manager",
-  "version": "1.47.1",
+  "version": "1.47.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cv-manager",
-      "version": "1.47.1",
+      "version": "1.47.2",
       "dependencies": {
         "archiver": "^7.0.1",
         "better-sqlite3": "^9.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cv-manager",
-  "version": "1.47.1",
+  "version": "1.47.2",
   "description": "Professional CV Management System",
   "main": "src/server.js",
   "scripts": {

--- a/public-readonly/index.html
+++ b/public-readonly/index.html
@@ -391,6 +391,7 @@
                 pic.onload = () => { pic.style.display = 'block'; initials.style.display = 'none'; };
                 pic.onerror = () => { pic.style.display = 'none'; initials.style.display = 'block'; };
                 pic.src = '/uploads/' + encodeURIComponent(fname) + '?' + new Date().getTime();
+                if (typeof applyProfilePictureCrop === 'function') applyProfilePictureCrop(pic, p.picture_crop);
                 profileImg.style.display = 'flex';
             } else {
                 pic.onload = null;

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.47.1",
+  "version": "1.47.2",
   "changelog": "https://github.com/vincentmakes/cv-manager/blob/main/CHANGELOG.md"
 }


### PR DESCRIPTION
The public page has two render paths: the live-profile path via scripts.js's shared loadProfile (already updated), and a separate inline renderProfileFromData in public-readonly/index.html used when a default dataset is configured. The inline one had no knowledge of picture_crop, so crops saved in the admin stayed invisible on the public site as long as a default dataset existed.

Bump to 1.47.2.

## Description

<!-- What does this PR do? Why is this change needed? -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (changes to docs only — no version bump needed)
- [ ] Translation (new or updated language files)
- [ ] Refactoring (no functional changes)

## Checklist

### Required for all code changes

- [ ] I have tested my changes locally (`npm test` passes)
- [ ] Version has been bumped in all 3 files (`package.json`, `package-lock.json`, `version.json`)
- [ ] `CHANGELOG.md` has been updated with a new entry under the correct version

### If adding or changing user-visible strings

- [ ] No hardcoded English — all strings use `t('key')` in JS or `data-i18n` in HTML
- [ ] New i18n keys added to `en.json` and all 7 other locale files (`de`, `fr`, `nl`, `es`, `it`, `pt`, `zh`)
- [ ] `escapeHtml()` used for any user-provided content rendered as HTML

### If documentation-only change

- [ ] No version bump included (docs changes must not bump the version)

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->
