### PR TITLE
Fix profile picture crop drift for off-centre crops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to CV Manager will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/), versioning follows [Semantic Versioning](https://semver.org/).
 
+## [1.47.3] - 2026-04-22
+
+### Fixed
+- **Rendered profile picture no longer drifts and appears "more zoomed in" than the cropper box for off-centre crops.** `applyProfilePictureCrop` in `public/shared/scripts.js` was combining `object-position: P% Q%` with a matching `transform-origin: P% Q%` and `transform: scale(zoom)`. That combination is geometrically correct only when the crop is centred on the image — for any other crop, `object-position` anchors the chosen image point at the *element's* P% position (not the container's centre), and the matching `transform-origin` keeps it there through the scale, so the rendered crop sits off-axis, gets clipped on one side, and shows image content from outside the crop on the other side (visually "more zoomed and shifted"). Replaced with the correct model: keep the image centred via default `object-position`, then translate+scale from the element centre with `tx% = -zoom·(W/L)·offsetX`, `ty% = -zoom·(H/L)·offsetY` where `L = min(W,H)`. This makes the crop centre land exactly at the container centre for any aspect ratio. Requires `naturalWidth`/`naturalHeight`, so the helper now defers via a one-shot `load` listener when the image hasn't finished loading yet — using `addEventListener` rather than `.onload` so callers that wired their own `pic.onload` display toggle aren't clobbered. The stored crop encoding is unchanged, so existing datasets and DB rows render correctly on first load without migration. Added six regression tests covering the new math across landscape, portrait, and square images and the deferred-load path.
+
 ## [1.47.2] - 2026-04-21
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cv-manager",
-  "version": "1.47.2",
+  "version": "1.47.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cv-manager",
-      "version": "1.47.2",
+      "version": "1.47.3",
       "dependencies": {
         "archiver": "^7.0.1",
         "better-sqlite3": "^9.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cv-manager",
-  "version": "1.47.2",
+  "version": "1.47.3",
   "description": "Professional CV Management System",
   "main": "src/server.js",
   "scripts": {

--- a/public/shared/scripts.js
+++ b/public/shared/scripts.js
@@ -334,8 +334,15 @@ function escapeHtml(text) {
 }
 
 // Apply stored crop metadata to a profile-picture <img>. The crop is expressed as
-// percent offsets (-100..100) and a scale factor (1..4). We use object-position +
-// transform with a shared origin so the visible centre stays anchored through scale.
+// percent offsets (-100..100 of the image's own W/H) and a scale factor (1..4,
+// equal to L/s where L = min(W,H) and s is the crop-box side). The <img> uses
+// object-fit:cover, which first scales the image uniformly by S/L and centres
+// it in the container. We then apply translate+scale around the element centre
+// so the crop's centre lands at the container centre regardless of aspect ratio.
+// Formula: tx% = -z·(W/L)·offsetX, ty% = -z·(H/L)·offsetY.
+// Requires naturalWidth/naturalHeight, so we defer via a one-shot load listener
+// when the image hasn't finished loading yet — addEventListener (not .onload)
+// so callers that wired their own pic.onload for display toggling aren't clobbered.
 // Accepts either a JSON string (as stored in DB) or a parsed object; null/invalid
 // clears all crop-related inline styles so default framing is restored.
 function applyProfilePictureCrop(imgEl, crop) {
@@ -359,11 +366,18 @@ function applyProfilePictureCrop(imgEl, crop) {
         imgEl.style.transformOrigin = '';
         return;
     }
-    const posX = 50 + ox;
-    const posY = 50 + oy;
-    imgEl.style.objectPosition = `${posX}% ${posY}%`;
-    imgEl.style.transformOrigin = `${posX}% ${posY}%`;
-    imgEl.style.transform = `scale(${z})`;
+    const W = imgEl.naturalWidth;
+    const H = imgEl.naturalHeight;
+    if (!W || !H) {
+        imgEl.addEventListener('load', () => applyProfilePictureCrop(imgEl, crop), { once: true });
+        return;
+    }
+    const L = Math.min(W, H);
+    const tx = -z * (W / L) * ox;
+    const ty = -z * (H / L) * oy;
+    imgEl.style.objectPosition = '';
+    imgEl.style.transformOrigin = '';
+    imgEl.style.transform = `translate(${tx}%, ${ty}%) scale(${z})`;
 }
 
 // Validate that a string is an http(s) URL. Used for optional URL fields.

--- a/tests/frontend.test.js
+++ b/tests/frontend.test.js
@@ -729,6 +729,140 @@ describe('Frontend files', () => {
                     `zoom round-trip for ${W}x${H}: got ${round.zoom}, expected ${crop.zoom}`);
             }
         });
+
+        // Extract applyProfilePictureCrop from scripts.js and run it against a
+        // stubbed <img>. The geometry contract: for a stored crop (offsetX%,
+        // offsetY%, zoom) the helper must write
+        //   transform: translate(tx%, ty%) scale(z)
+        // where tx% = -z·(W/L)·offsetX, ty% = -z·(H/L)·offsetY and L = min(W,H).
+        // This guarantees the crop centre lands at the container centre after
+        // object-fit:cover, regardless of image aspect ratio.
+        function loadApplyProfilePictureCrop() {
+            const js = fs.readFileSync(path.join(ROOT, 'public', 'shared', 'scripts.js'), 'utf8');
+            const m = js.match(/function applyProfilePictureCrop\(imgEl, crop\)\s*\{[\s\S]*?^\}/m);
+            assert.ok(m, 'applyProfilePictureCrop should exist in scripts.js');
+            // Keep the declaration intact so the deferred-load path can self-reference
+            // via its own name (addEventListener → applyProfilePictureCrop(imgEl, crop)).
+            const loader = new Function(`${m[0]}\nreturn applyProfilePictureCrop;`);
+            return loader();
+        }
+
+        function stubImg(W, H, { complete = true } = {}) {
+            const listeners = [];
+            return {
+                naturalWidth: complete ? W : 0,
+                naturalHeight: complete ? H : 0,
+                complete,
+                style: {
+                    objectPosition: 'X',
+                    transform: 'X',
+                    transformOrigin: 'X'
+                },
+                addEventListener(type, cb) { if (type === 'load') listeners.push(cb); },
+                _fireLoad() { listeners.splice(0).forEach(cb => cb()); }
+            };
+        }
+
+        function parseTransform(str) {
+            const m = /translate\(([-\d.]+)%, ([-\d.]+)%\) scale\(([-\d.]+)\)/.exec(str || '');
+            if (!m) return null;
+            return { tx: parseFloat(m[1]), ty: parseFloat(m[2]), z: parseFloat(m[3]) };
+        }
+
+        it('applyProfilePictureCrop: null/invalid crop clears inline styles', () => {
+            const apply = loadApplyProfilePictureCrop();
+            const img = stubImg(1000, 1000);
+            apply(img, null);
+            assert.strictEqual(img.style.objectPosition, '');
+            assert.strictEqual(img.style.transform, '');
+            assert.strictEqual(img.style.transformOrigin, '');
+        });
+
+        it('applyProfilePictureCrop: identity crop (offsets 0, zoom 1) clears styles', () => {
+            const apply = loadApplyProfilePictureCrop();
+            const img = stubImg(1200, 800);
+            apply(img, { offsetX: 0, offsetY: 0, zoom: 1 });
+            assert.strictEqual(img.style.objectPosition, '');
+            assert.strictEqual(img.style.transform, '');
+            assert.strictEqual(img.style.transformOrigin, '');
+        });
+
+        it('applyProfilePictureCrop: centered crop with zoom > 1 is a pure scale', () => {
+            const apply = loadApplyProfilePictureCrop();
+            const img = stubImg(2000, 1000);
+            apply(img, { offsetX: 0, offsetY: 0, zoom: 1.5 });
+            const t = parseTransform(img.style.transform);
+            assert.ok(t, `expected translate/scale, got: ${img.style.transform}`);
+            const near = (a, b) => Math.abs(a - b) < 1e-6;
+            assert.ok(near(t.tx, 0), `tx=${t.tx}`);
+            assert.ok(near(t.ty, 0), `ty=${t.ty}`);
+            assert.ok(near(t.z, 1.5), `z=${t.z}`);
+            assert.strictEqual(img.style.objectPosition, '');
+            assert.strictEqual(img.style.transformOrigin, '');
+        });
+
+        it('applyProfilePictureCrop: landscape off-centre crop uses W/L factor on tx', () => {
+            const apply = loadApplyProfilePictureCrop();
+            const W = 2000, H = 1000;                // L = 1000, W/L = 2
+            const img = stubImg(W, H);
+            const crop = { offsetX: -25, offsetY: 0, zoom: 1.25 };
+            apply(img, crop);
+            const t = parseTransform(img.style.transform);
+            assert.ok(t, `expected translate/scale, got: ${img.style.transform}`);
+            // tx% = -z·(W/L)·offsetX = -1.25 · 2 · (-25) = 62.5
+            const near = (a, b) => Math.abs(a - b) < 1e-6;
+            assert.ok(near(t.tx, 62.5), `tx=${t.tx} expected 62.5`);
+            assert.ok(near(t.ty, 0), `ty=${t.ty} expected 0`);
+            assert.ok(near(t.z, 1.25), `z=${t.z} expected 1.25`);
+        });
+
+        it('applyProfilePictureCrop: portrait off-centre crop uses H/L factor on ty', () => {
+            const apply = loadApplyProfilePictureCrop();
+            const W = 600, H = 900;                  // L = 600, H/L = 1.5
+            const img = stubImg(W, H);
+            const crop = { offsetX: 0, offsetY: 10, zoom: 1.5 };
+            apply(img, crop);
+            const t = parseTransform(img.style.transform);
+            assert.ok(t, `expected translate/scale, got: ${img.style.transform}`);
+            // ty% = -z·(H/L)·offsetY = -1.5 · 1.5 · 10 = -22.5
+            const near = (a, b) => Math.abs(a - b) < 1e-6;
+            assert.ok(near(t.tx, 0), `tx=${t.tx} expected 0`);
+            assert.ok(near(t.ty, -22.5), `ty=${t.ty} expected -22.5`);
+            assert.ok(near(t.z, 1.5), `z=${t.z} expected 1.5`);
+        });
+
+        it('applyProfilePictureCrop: square image off-centre both axes', () => {
+            const apply = loadApplyProfilePictureCrop();
+            const img = stubImg(1000, 1000);          // W = H = L, W/L = H/L = 1
+            const crop = { offsetX: 25, offsetY: -10, zoom: 2 };
+            apply(img, crop);
+            const t = parseTransform(img.style.transform);
+            assert.ok(t, `expected translate/scale, got: ${img.style.transform}`);
+            // tx% = -2·1·25 = -50 ; ty% = -2·1·(-10) = 20
+            const near = (a, b) => Math.abs(a - b) < 1e-6;
+            assert.ok(near(t.tx, -50), `tx=${t.tx} expected -50`);
+            assert.ok(near(t.ty, 20), `ty=${t.ty} expected 20`);
+            assert.ok(near(t.z, 2), `z=${t.z} expected 2`);
+        });
+
+        it('applyProfilePictureCrop: defers when image not yet loaded, applies on load', () => {
+            const apply = loadApplyProfilePictureCrop();
+            const img = stubImg(2000, 1000, { complete: false });
+            const crop = { offsetX: -25, offsetY: 0, zoom: 1.25 };
+            apply(img, crop);
+            // Nothing written synchronously because natural dims are unknown.
+            assert.strictEqual(img.style.transform, 'X', 'must not write transform before load');
+            // Simulate the image finishing load and expose naturalWidth/Height.
+            img.naturalWidth = 2000;
+            img.naturalHeight = 1000;
+            img.complete = true;
+            img._fireLoad();
+            const t = parseTransform(img.style.transform);
+            assert.ok(t, `expected translate/scale after load, got: ${img.style.transform}`);
+            const near = (a, b) => Math.abs(a - b) < 1e-6;
+            assert.ok(near(t.tx, 62.5), `tx=${t.tx} expected 62.5`);
+            assert.ok(near(t.z, 1.25), `z=${t.z} expected 1.25`);
+        });
     });
 
     describe('Code quality', () => {

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.47.2",
+  "version": "1.47.3",
   "changelog": "https://github.com/vincentmakes/cv-manager/blob/main/CHANGELOG.md"
 }


### PR DESCRIPTION
## Description

Fixes a geometry bug in `applyProfilePictureCrop` that caused rendered profile pictures to drift and appear "more zoomed in" than the cropper box when crops were off-centre.

The previous implementation combined `object-position: P% Q%` with a matching `transform-origin: P% Q%` and `transform: scale(zoom)`. This is only geometrically correct for centred crops. For off-centre crops, `object-position` anchors the chosen image point at the *element's* P% position (not the container's centre), and the matching `transform-origin` keeps it there through the scale, causing the rendered crop to sit off-axis, get clipped on one side, and show image content from outside the crop box.

**The fix:** Replace with the correct model using `translate(tx%, ty%) scale(z)` where:
- `tx% = -zoom·(W/L)·offsetX`
- `ty% = -zoom·(H/L)·offsetY`
- `L = min(W, H)`

This makes the crop centre land exactly at the container centre for any aspect ratio. The helper now defers via a one-shot `load` listener when `naturalWidth`/`naturalHeight` aren't yet available, using `addEventListener` (not `.onload`) to avoid clobbering caller-wired load handlers.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

### Required for all code changes

- [x] I have tested my changes locally (`npm test` passes)
- [x] Version has been bumped in all 3 files (`package.json`, `package-lock.json`, `version.json`)
- [x] `CHANGELOG.md` has been updated with a new entry under the correct version

### If adding or changing user-visible strings

- [x] N/A — no user-visible strings changed

### If documentation-only change

- [x] N/A — code changes included

## Test Plan

Added comprehensive unit tests in `tests/frontend.test.js` covering:
- Null/invalid crop clears styles
- Identity crop (offsets 0, zoom 1) clears styles
- Centred crop with zoom > 1 is a pure scale
- Landscape off-centre crop uses W/L factor on tx
- Portrait off-centre crop uses H/L factor on ty
- Square image off-centre on both axes
- Deferred application when image not yet loaded, applies on load event

All tests verify the transform formula against the documented geometry contract.

https://claude.ai/code/session_01V6g4sngEajmbmKFm5GCsNg