### PR TITLE
Add bold text formatting via **double asterisks** in text fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to CV Manager will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/), versioning follows [Semantic Versioning](https://semver.org/).
 
+## [1.48.0] - 2026-04-23
+
+### Added
+- **Bold text formatting via `**double asterisks**` in long-form text fields.** Professional summary (bio), experience summary and highlights, education description, project description, and every custom-section description (grid / list / cards / bullet-list / free-text / timeline summary+highlights) now render `**word**` as **word** on both the admin preview and the public read-only site. New shared `escapeHtmlWithBold` helper in `public/shared/scripts.js` applies HTML-entity escaping first and only then swaps `**…**` for `<strong>…</strong>`, so the transformation is XSS-safe: a bio of `<script>**x**</script>` renders as escaped text containing a bold "x", never as an executing script. The regex refuses to span newlines so an unclosed `**` on one line cannot bleed across fields. On the server side, a matching `stripBoldMarkers` is applied to the SEO meta description / `og:description` tags (including the static-site export) so the `**` never leaks into search previews, and the ATS PDF export's `addParagraph` / `addBulletList` helpers now parse bold runs and render them with `Helvetica-Bold`, keeping a single tagged `<P>`/`<LI>` PDF struct per paragraph so accessibility tagging does not regress. A small hint — "Tip: wrap text in \*\*double asterisks\*\* to make it bold." — sits under every affected textarea, translated across all 8 supported locales (`form.bold_hint` in en/de/fr/nl/es/it/pt/zh). Non-goals: italics, links, lists, headings, and auto-`\n`→`<br>` conversion are intentionally out of scope for this release.
+
 ## [1.47.3] - 2026-04-22
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cv-manager",
-  "version": "1.47.3",
+  "version": "1.48.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cv-manager",
-      "version": "1.47.3",
+      "version": "1.48.0",
       "dependencies": {
         "archiver": "^7.0.1",
         "better-sqlite3": "^9.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cv-manager",
-  "version": "1.47.3",
+  "version": "1.48.0",
   "description": "Professional CV Management System",
   "main": "src/server.js",
   "scripts": {

--- a/public-readonly/index.html
+++ b/public-readonly/index.html
@@ -380,7 +380,7 @@
             document.getElementById('profileName').textContent = p.name || '';
             document.getElementById('profileTitle').textContent = p.title || '';
             document.getElementById('profileSubtitle').textContent = p.subtitle || '';
-            document.getElementById('aboutText').textContent = p.bio || '';
+            document.getElementById('aboutText').innerHTML = escapeHtmlWithBold(p.bio || '');
             if (p.name) document.title = `${p.name} - CV`;
             
             const pic = document.getElementById('profilePicture');
@@ -541,7 +541,7 @@
                         </div>
                         <span class="item-date">${formatDate(edu.start_date) || escapeHtml(edu.start_date || '')} - ${edu.end_date ? (formatDate(edu.end_date) || escapeHtml(edu.end_date)) : t('present')}</span>
                     </div>
-                    ${edu.description ? `<div class="item-location">${escapeHtml(edu.description)}</div>` : ''}
+                    ${edu.description ? `<div class="item-location">${escapeHtmlWithBold(edu.description)}</div>` : ''}
                 </article>
             `).join('');
         }
@@ -569,7 +569,7 @@
                         <h3 class="project-title" itemprop="name">${escapeHtml(proj.title)}</h3>
                         ${proj.link ? `<a href="${escapeHtml(proj.link)}" class="project-link" target="_blank" rel="noopener" title="${t('view_project')}">${icons.link}</a>` : ''}
                     </div>
-                    <p class="project-description" itemprop="description">${escapeHtml(proj.description || '')}</p>
+                    <p class="project-description" itemprop="description">${escapeHtmlWithBold(proj.description || '')}</p>
                     <div class="tech-tags">${(proj.technologies || []).map(t => `<span class="tech-tag">${escapeHtml(t)}</span>`).join('')}</div>
                 </article>
             `).join('');

--- a/public/shared/admin.js
+++ b/public/shared/admin.js
@@ -1452,6 +1452,7 @@ function profileForm(d) {
         <div class="form-group">
             <label class="form-label">${t('form.bio')}</label>
             <textarea class="form-textarea" id="f-bio">${escapeHtml(d.bio || '')}</textarea>
+            <div class="form-hint">${t('form.bold_hint')}</div>
         </div>
         <div class="form-row">
             <div class="form-group">
@@ -1548,10 +1549,12 @@ function experienceForm(d) {
         <div class="form-group">
             <label class="form-label">${t('form.summary')}</label>
             <textarea class="form-textarea" id="f-summary" rows="3">${escapeHtml(d.summary || '')}</textarea>
+            <div class="form-hint">${t('form.bold_hint')}</div>
         </div>
         <div class="form-group">
             <label class="form-label">${t('form.highlights')}</label>
             <textarea class="form-textarea" id="f-highlights" rows="6">${(d.highlights || []).join('\n')}</textarea>
+            <div class="form-hint">${t('form.bold_hint')}</div>
         </div>
     `;
 }
@@ -1626,6 +1629,7 @@ function educationForm(d) {
         <div class="form-group">
             <label class="form-label">${t('form.description')}</label>
             <textarea class="form-textarea" id="f-description">${escapeHtml(d.description || '')}</textarea>
+            <div class="form-hint">${t('form.bold_hint')}</div>
         </div>
     `;
 }
@@ -1720,6 +1724,7 @@ function projectForm(d) {
         <div class="form-group">
             <label class="form-label">${t('form.description')}</label>
             <textarea class="form-textarea" id="f-description">${escapeHtml(d.description || '')}</textarea>
+            <div class="form-hint">${t('form.bold_hint')}</div>
         </div>
         <div class="form-group">
             <label class="form-label">${t('form.technologies')}</label>
@@ -5904,6 +5909,7 @@ function openCustomItemModal(sectionId, itemId = null) {
             <div class="form-group">
                 <label class="form-label">${t('custom_item.bullet_points')}</label>
                 <textarea class="form-textarea" id="ci-description" rows="8" placeholder="First bullet point\nSecond bullet point\nThird bullet point">${escapeHtml(item.description || '')}</textarea>
+                <div class="form-hint">${t('form.bold_hint')}</div>
             </div>
         `;
     } else if (section.layout_type === 'free-text') {
@@ -5925,6 +5931,7 @@ function openCustomItemModal(sectionId, itemId = null) {
                 <label class="form-label">${t('custom_item.text_content')}</label>
                 <textarea class="form-textarea" id="ci-description" rows="10" placeholder="${t('custom_item.text_content_placeholder')}">${escapeHtml(item.description || '')}</textarea>
                 <div class="form-hint">${t('custom_item.text_content_hint')}</div>
+                <div class="form-hint">${t('form.bold_hint')}</div>
             </div>
         `;
     } else if (section.layout_type === 'timeline') {
@@ -5966,10 +5973,12 @@ function openCustomItemModal(sectionId, itemId = null) {
             <div class="form-group">
                 <label class="form-label">${t('form.summary')}</label>
                 <textarea class="form-textarea" id="ci-summary" rows="3">${escapeHtml(meta.summary || '')}</textarea>
+                <div class="form-hint">${t('form.bold_hint')}</div>
             </div>
             <div class="form-group">
                 <label class="form-label">${t('form.highlights')}</label>
                 <textarea class="form-textarea" id="ci-description" rows="6">${escapeHtml(item.description || '')}</textarea>
+                <div class="form-hint">${t('form.bold_hint')}</div>
             </div>
         `;
     } else if (section.layout_type === 'picture-grid') {
@@ -6016,6 +6025,7 @@ function openCustomItemModal(sectionId, itemId = null) {
             <div class="form-group">
                 <label class="form-label">${t('custom_item.description_optional')}</label>
                 <textarea class="form-textarea" id="ci-description">${escapeHtml(item.description || '')}</textarea>
+                <div class="form-hint">${t('form.bold_hint')}</div>
             </div>
             <div class="form-group">
                 <label class="form-label">${t('custom_item.link_url_optional')}</label>

--- a/public/shared/i18n/de.json
+++ b/public/shared/i18n/de.json
@@ -142,6 +142,7 @@
     "form.choose_image": "Bild auswählen",
     "form.remove": "Entfernen",
     "form.picture_hint": "Empfohlen: Quadratisches Bild, mindestens 200x200 Pixel. JPEG, PNG oder WebP.",
+    "form.bold_hint": "Tipp: Text in **doppelten Sternchen** einschließen, um ihn fett darzustellen.",
     "form.apply_picture_globally": "Dieses Bild auf alle Datensätze anwenden",
     "form.delete_picture": "Bild löschen",
     "form.no_pictures_available": "Noch keine Bilder in der Bibliothek. Laden Sie zuerst eines hoch.",

--- a/public/shared/i18n/en.json
+++ b/public/shared/i18n/en.json
@@ -141,6 +141,7 @@
     "form.zoom": "Zoom",
     "form.remove": "Remove",
     "form.picture_hint": "Recommended: Square image, at least 200x200 pixels. JPEG, PNG or WebP.",
+    "form.bold_hint": "Tip: wrap text in **double asterisks** to make it bold.",
     "form.apply_picture_globally": "Apply this picture to all datasets",
     "form.delete_picture": "Delete picture",
     "form.no_pictures_available": "No pictures in the library yet. Upload one first.",

--- a/public/shared/i18n/es.json
+++ b/public/shared/i18n/es.json
@@ -142,6 +142,7 @@
     "form.choose_image": "Elegir imagen",
     "form.remove": "Eliminar",
     "form.picture_hint": "Recomendado: imagen cuadrada, al menos 200x200 píxeles. JPEG, PNG o WebP.",
+    "form.bold_hint": "Consejo: rodea el texto con **dobles asteriscos** para ponerlo en negrita.",
     "form.apply_picture_globally": "Aplicar esta foto a todos los conjuntos de datos",
     "form.delete_picture": "Eliminar foto",
     "form.no_pictures_available": "Aún no hay fotos en la biblioteca. Sube una primero.",

--- a/public/shared/i18n/fr.json
+++ b/public/shared/i18n/fr.json
@@ -142,6 +142,7 @@
     "form.choose_image": "Choisir une image",
     "form.remove": "Supprimer",
     "form.picture_hint": "Recommandé : Image carrée, au moins 200x200 pixels. JPEG, PNG ou WebP.",
+    "form.bold_hint": "Astuce : entourez le texte de **doubles astérisques** pour le mettre en gras.",
     "form.apply_picture_globally": "Appliquer cette photo à tous les jeux de données",
     "form.delete_picture": "Supprimer la photo",
     "form.no_pictures_available": "Aucune photo dans la bibliothèque. Téléchargez-en une d'abord.",

--- a/public/shared/i18n/it.json
+++ b/public/shared/i18n/it.json
@@ -142,6 +142,7 @@
     "form.choose_image": "Scegli immagine",
     "form.remove": "Rimuovi",
     "form.picture_hint": "Consigliato: immagine quadrata, almeno 200x200 pixel. JPEG, PNG o WebP.",
+    "form.bold_hint": "Suggerimento: racchiudi il testo tra **doppi asterischi** per metterlo in grassetto.",
     "form.apply_picture_globally": "Applica questa foto a tutti i dataset",
     "form.delete_picture": "Elimina foto",
     "form.no_pictures_available": "Nessuna foto nella libreria. Caricane una prima.",

--- a/public/shared/i18n/nl.json
+++ b/public/shared/i18n/nl.json
@@ -142,6 +142,7 @@
     "form.choose_image": "Afbeelding kiezen",
     "form.remove": "Verwijderen",
     "form.picture_hint": "Aanbevolen: Vierkante afbeelding, minimaal 200x200 pixels. JPEG, PNG of WebP.",
+    "form.bold_hint": "Tip: zet tekst tussen **dubbele sterretjes** om het vet te maken.",
     "form.apply_picture_globally": "Deze foto toepassen op alle datasets",
     "form.delete_picture": "Foto verwijderen",
     "form.no_pictures_available": "Nog geen foto's in de bibliotheek. Upload er eerst een.",

--- a/public/shared/i18n/pt.json
+++ b/public/shared/i18n/pt.json
@@ -142,6 +142,7 @@
     "form.choose_image": "Escolher Imagem",
     "form.remove": "Remover",
     "form.picture_hint": "Recomendado: Imagem quadrada, pelo menos 200x200 pixels. JPEG, PNG ou WebP.",
+    "form.bold_hint": "Dica: envolva o texto com **duplos asteriscos** para deixá-lo em negrito.",
     "form.apply_picture_globally": "Aplicar esta foto a todos os conjuntos de dados",
     "form.delete_picture": "Eliminar foto",
     "form.no_pictures_available": "Ainda não há fotos na biblioteca. Carregue uma primeiro.",

--- a/public/shared/i18n/zh.json
+++ b/public/shared/i18n/zh.json
@@ -142,6 +142,7 @@
     "form.choose_image": "选择图片",
     "form.remove": "移除",
     "form.picture_hint": "建议：正方形图片，至少 200x200 像素。支持 JPEG、PNG 或 WebP 格式。",
+    "form.bold_hint": "提示：用 **双星号** 包裹文本可将其加粗。",
     "form.apply_picture_globally": "将此照片应用于所有数据集",
     "form.delete_picture": "删除照片",
     "form.no_pictures_available": "图库中还没有照片。请先上传一张。",

--- a/public/shared/scripts.js
+++ b/public/shared/scripts.js
@@ -333,6 +333,16 @@ function escapeHtml(text) {
     return div.innerHTML;
 }
 
+// Escape HTML, then render **word** as <strong>word</strong>.
+// Escaping runs first, so only safe entities remain before we inject <strong>.
+// The regex is non-greedy and forbids newlines / nested asterisks, so an
+// unclosed ** on one line cannot bold across fields or lines.
+function escapeHtmlWithBold(text) {
+    if (text == null || text === '') return '';
+    const escaped = escapeHtml(String(text));
+    return escaped.replace(/\*\*([^*\n]+?)\*\*/g, '<strong>$1</strong>');
+}
+
 // Apply stored crop metadata to a profile-picture <img>. The crop is expressed as
 // percent offsets (-100..100 of the image's own W/H) and a scale factor (1..4,
 // equal to L/s where L = min(W,H) and s is the crop-box side). The <img> uses
@@ -704,8 +714,8 @@ async function loadProfile(includePrivate = false) {
     document.getElementById('profileTitle').textContent = p.title || '';
     document.getElementById('profileSubtitle').textContent = p.subtitle || '';
     
-    // Bio - CSS white-space: pre-line handles line breaks
-    document.getElementById('aboutText').textContent = p.bio || '';
+    // Bio - CSS white-space: pre-line handles line breaks; **bold** is rendered as <strong>
+    document.getElementById('aboutText').innerHTML = escapeHtmlWithBold(p.bio || '');
     
     // Update page title
     if (p.name) document.title = `${p.name} - CV`;
@@ -1441,7 +1451,7 @@ async function loadExperiencesReadOnly() {
             ${exp.location ? `<div class="item-location">${escapeHtml(exp.location)}</div>` : ''}
             ${exp.highlights && exp.highlights.length ? `
                 <ul class="item-highlights" itemprop="description">
-                    ${exp.highlights.map(h => `<li>${escapeHtml(h)}</li>`).join('')}
+                    ${exp.highlights.map(h => `<li>${escapeHtmlWithBold(h)}</li>`).join('')}
                 </ul>
             ` : ''}
         </article>
@@ -1491,7 +1501,7 @@ async function loadEducationReadOnly() {
                     <time datetime="${edu.end_date || ''}">${edu.end_date ? (formatDate(edu.end_date) || escapeHtml(edu.end_date)) : t('present')}</time>
                 </span>
             </div>
-            ${edu.description ? `<div class="item-location" itemprop="description">${escapeHtml(edu.description)}</div>` : ''}
+            ${edu.description ? `<div class="item-location" itemprop="description">${escapeHtmlWithBold(edu.description)}</div>` : ''}
         </article>
     `).join('');
 }
@@ -1525,7 +1535,7 @@ async function loadProjectsReadOnly() {
                 <h3 class="project-title" itemprop="name">${escapeHtml(proj.title)}</h3>
                 ${proj.link ? `<a href="${escapeHtml(proj.link)}" class="project-link" target="_blank" rel="noopener" itemprop="url" title="${t('view_project')}">${icons.link}</a>` : ''}
             </div>
-            <p class="project-description" itemprop="description">${escapeHtml(proj.description || '')}</p>
+            <p class="project-description" itemprop="description">${escapeHtmlWithBold(proj.description || '')}</p>
             <div class="tech-tags">
                 ${(proj.technologies || []).map(t => `<span class="tech-tag" itemprop="keywords">${escapeHtml(t)}</span>`).join('')}
             </div>
@@ -1717,13 +1727,13 @@ function renderExperienceCard(opts) {
         : '';
 
     const summaryHtml = summary
-        ? `<div class="item-summary">${escapeHtml(summary)}</div>`
+        ? `<div class="item-summary">${escapeHtmlWithBold(summary)}</div>`
         : '';
 
     let highlightsHtml = '';
     if (highlights.length) {
         const itemProp = schemaOrg ? ' itemprop="description"' : '';
-        highlightsHtml = `<ul class="item-highlights"${itemProp}>${highlights.map(h => `<li>${escapeHtml(h)}</li>`).join('')}</ul>`;
+        highlightsHtml = `<ul class="item-highlights"${itemProp}>${highlights.map(h => `<li>${escapeHtmlWithBold(h)}</li>`).join('')}</ul>`;
     }
 
     const classes = ['item-card', visClass, logoClass, extraClasses].filter(Boolean).join(' ');
@@ -1839,7 +1849,7 @@ function renderGridPublic(items, cols) {
         <div class="custom-grid-item">
             ${item.title && !hideTitle ? `<h3 class="custom-item-title">${escapeHtml(item.title)}</h3>` : ''}
             ${item.subtitle ? `<div class="custom-item-subtitle">${escapeHtml(item.subtitle)}</div>` : ''}
-            ${item.description ? `<p class="custom-item-description">${escapeHtml(item.description)}</p>` : ''}
+            ${item.description ? `<p class="custom-item-description">${escapeHtmlWithBold(item.description)}</p>` : ''}
             ${item.link ? `<a href="${escapeHtml(item.link)}" class="custom-item-link" target="_blank" rel="noopener">${t('view_link')}</a>` : ''}
         </div>
     `;
@@ -1856,7 +1866,7 @@ function renderListPublic(items) {
             <div class="custom-list-content">
                 ${item.title && !hideTitle ? `<h3 class="custom-item-title">${escapeHtml(item.title)}</h3>` : ''}
                 ${item.subtitle ? `<div class="custom-item-subtitle">${escapeHtml(item.subtitle)}</div>` : ''}
-                ${item.description ? `<p class="custom-item-description">${escapeHtml(item.description)}</p>` : ''}
+                ${item.description ? `<p class="custom-item-description">${escapeHtmlWithBold(item.description)}</p>` : ''}
             </div>
             ${item.link ? `<a href="${escapeHtml(item.link)}" class="custom-item-link" target="_blank" rel="noopener">${t('view_link')}</a>` : ''}
         </div>
@@ -1873,7 +1883,7 @@ function renderCardsPublic(items) {
         <div class="custom-card">
             ${item.title && !hideTitle ? `<h3 class="custom-card-title">${escapeHtml(item.title)}</h3>` : ''}
             ${item.subtitle ? `<div class="custom-card-subtitle">${escapeHtml(item.subtitle)}</div>` : ''}
-            ${item.description ? `<p class="custom-card-description">${escapeHtml(item.description)}</p>` : ''}
+            ${item.description ? `<p class="custom-card-description">${escapeHtmlWithBold(item.description)}</p>` : ''}
             ${item.link ? `<a href="${escapeHtml(item.link)}" class="custom-card-link" target="_blank" rel="noopener">${t('learn_more')}</a>` : ''}
         </div>
     `;
@@ -1896,7 +1906,7 @@ function renderBulletListPublic(items) {
                 ${item.title && !hideTitle ? `<h3 class="custom-bullet-title">${escapeHtml(item.title)}</h3>` : ''}
                 ${bullets.length > 0 ? `
                     <ul class="custom-bullet-list">
-                        ${bullets.map(bullet => `<li>${escapeHtml(bullet)}</li>`).join('')}
+                        ${bullets.map(bullet => `<li>${escapeHtmlWithBold(bullet)}</li>`).join('')}
                     </ul>
                 ` : ''}
             </div>
@@ -1941,7 +1951,7 @@ function renderFreeTextPublic(items) {
         return `
             <div class="custom-free-text">
                 ${showTitle ? `<div class="custom-item-title">${escapeHtml(item.title)}</div>` : ''}
-                <p class="custom-free-text-content">${escapeHtml(item.description || '')}</p>
+                <p class="custom-free-text-content">${escapeHtmlWithBold(item.description || '')}</p>
             </div>
         `;
     }).join('')}</div>`;

--- a/src/server.js
+++ b/src/server.js
@@ -119,6 +119,32 @@ function resolveLocale(requested) {
     return 'en';
 }
 
+// Remove **bold** markers for plain-text contexts (SEO meta, ATS text, etc.).
+// Mirrors the client-side regex in escapeHtmlWithBold (scripts.js).
+function stripBoldMarkers(text) {
+    if (text == null) return '';
+    return String(text).replace(/\*\*([^*\n]+?)\*\*/g, '$1');
+}
+
+// Split a paragraph into alternating regular/bold runs for rich rendering
+// (e.g. PDF). Returns an array of { text, bold } segments. Matches the same
+// regex as stripBoldMarkers / escapeHtmlWithBold for a single source of truth.
+function splitBoldRuns(text) {
+    const s = text == null ? '' : String(text);
+    const runs = [];
+    const re = /\*\*([^*\n]+?)\*\*/g;
+    let last = 0;
+    let m;
+    while ((m = re.exec(s)) !== null) {
+        if (m.index > last) runs.push({ text: s.slice(last, m.index), bold: false });
+        runs.push({ text: m[1], bold: true });
+        last = m.index + m[0].length;
+    }
+    if (last < s.length) runs.push({ text: s.slice(last), bold: false });
+    if (runs.length === 0) runs.push({ text: s, bold: false });
+    return runs;
+}
+
 function checkFilesystemAccess(dir) {
     const testFile = path.join(dir, '.write-test-' + process.pid);
     try {
@@ -223,7 +249,7 @@ function servePublicIndex(req, res) {
             const data = JSON.parse(defaultDataset.data);
             const name = data.profile?.name || defaultDataset.name;
             const bio = data.profile?.bio || 'Professional CV';
-            const description = bio.substring(0, 160).replace(/\n/g, ' ');
+            const description = stripBoldMarkers(bio).substring(0, 160).replace(/\n/g, ' ');
             const dsLang = defaultDataset.language || 'en';
 
             let html = fs.readFileSync(path.join(__dirname, '../public-readonly/index.html'), 'utf8');
@@ -258,7 +284,7 @@ function servePublicIndex(req, res) {
         const profile = db.prepare('SELECT name, title, bio FROM profile WHERE id = 1').get();
         const name = profile?.name || 'CV';
         const bio = profile?.bio || 'Professional CV';
-        const description = bio.substring(0, 160).replace(/\n/g, ' ');
+        const description = stripBoldMarkers(bio).substring(0, 160).replace(/\n/g, ' ');
 
         let html = fs.readFileSync(path.join(__dirname, '../public-readonly/index.html'), 'utf8');
         html = html.replace(/<title>[^<]*<\/title>/, `<title>${name} - CV</title>`);
@@ -296,7 +322,7 @@ function serveDatasetPage(req, res, lang) {
         const data = JSON.parse(dataset.data);
         const name = data.profile?.name || dataset.name;
         const bio = data.profile?.bio || '';
-        const description = bio.substring(0, 160).replace(/\n/g, ' ');
+        const description = stripBoldMarkers(bio).substring(0, 160).replace(/\n/g, ' ');
         const dsLang = dataset.language || 'en';
 
         let html = fs.readFileSync(path.join(__dirname, '../public-readonly/index.html'), 'utf8');
@@ -1534,7 +1560,7 @@ function serveAdminDatasetPage(req, res, lang) {
         const data = JSON.parse(dataset.data);
         const name = data.profile?.name || dataset.name;
         const bio = data.profile?.bio || '';
-        const description = bio.substring(0, 160).replace(/\n/g, ' ');
+        const description = stripBoldMarkers(bio).substring(0, 160).replace(/\n/g, ' ');
         const dsLang = dataset.language || 'en';
 
         let html = fs.readFileSync(path.join(__dirname, '../public-readonly/index.html'), 'utf8');
@@ -3564,13 +3590,30 @@ if (PUBLIC_ONLY) {
             function addParagraph(text, fontSize, options = {}) {
                 const { color = '#000', font = 'Helvetica', indent = 0 } = options;
                 const w = contentW - indent;
-                const h = doc.fontSize(fontSize).font(font).heightOfString(text, { width: w });
+                const runs = splitBoldRuns(text);
+                const stripped = runs.map(r => r.text).join('');
+                // Base font already bold → treat **…** as no-op (text is already bold).
+                const baseIsBold = font === 'Helvetica-Bold';
+                const boldFont = baseIsBold ? font : 'Helvetica-Bold';
+                const h = doc.fontSize(fontSize).font(font).heightOfString(stripped, { width: w });
                 ensureSpace(h + 2);
                 const para = doc.struct('P');
                 docStruct.add(para);
                 para.add(doc.struct('Span', {}, () => {
-                    doc.fontSize(fontSize).font(font).fillColor(color);
-                    doc.text(text, margin + indent, y, { width: w });
+                    doc.fontSize(fontSize).fillColor(color);
+                    if (runs.length === 1 || baseIsBold) {
+                        doc.font(font).text(stripped, margin + indent, y, { width: w });
+                    } else {
+                        runs.forEach((r, i) => {
+                            doc.font(r.bold ? boldFont : font);
+                            const opts = { width: w, continued: i < runs.length - 1 };
+                            if (i === 0) {
+                                doc.text(r.text, margin + indent, y, opts);
+                            } else {
+                                doc.text(r.text, opts);
+                            }
+                        });
+                    }
                 }));
                 para.end();
                 advanceY(h + 2);
@@ -3588,7 +3631,9 @@ if (PUBLIC_ONLY) {
                 items.forEach(item => {
                     if (!item || !item.trim()) return;
                     const w = contentW - 20;
-                    const h = doc.fontSize(fontSize).font('Helvetica').heightOfString(item, { width: w });
+                    const runs = splitBoldRuns(item);
+                    const stripped = runs.map(r => r.text).join('');
+                    const h = doc.fontSize(fontSize).font('Helvetica').heightOfString(stripped, { width: w });
                     ensureSpace(h + 2);
                     const li = doc.struct('LI');
                     listStruct.add(li);
@@ -3597,8 +3642,20 @@ if (PUBLIC_ONLY) {
                         doc.text('•', margin + 8, y, { continued: false, width: 12 });
                     }));
                     li.add(doc.struct('LBody', {}, () => {
-                        doc.fontSize(fontSize).font('Helvetica').fillColor('#000');
-                        doc.text(item, margin + 20, y, { width: w });
+                        doc.fontSize(fontSize).fillColor('#000');
+                        if (runs.length === 1) {
+                            doc.font('Helvetica').text(stripped, margin + 20, y, { width: w });
+                        } else {
+                            runs.forEach((r, i) => {
+                                doc.font(r.bold ? 'Helvetica-Bold' : 'Helvetica');
+                                const opts = { width: w, continued: i < runs.length - 1 };
+                                if (i === 0) {
+                                    doc.text(r.text, margin + 20, y, opts);
+                                } else {
+                                    doc.text(r.text, opts);
+                                }
+                            });
+                        }
                     }));
                     li.end();
                     advanceY(h + 2);
@@ -3894,7 +3951,7 @@ if (PUBLIC_ONLY) {
             // Inject meta tags
             const name = profile.name || 'CV';
             const bio = profile.bio || 'Professional CV';
-            const description = bio.substring(0, 160).replace(/\n/g, ' ');
+            const description = stripBoldMarkers(bio).substring(0, 160).replace(/\n/g, ' ');
             html = html.replace(/<title>[^<]*<\/title>/, `<title>${name} - CV</title>`);
             html = html.replace(/<meta name="description" content="[^"]*">/, `<meta name="description" content="${description.replace(/"/g, '&quot;')}">`);
 

--- a/tests/backend.test.js
+++ b/tests/backend.test.js
@@ -1407,6 +1407,85 @@ describe('Backend API', () => {
                 assert.ok(extractLangTag(buf), 'PDF should still carry a /Lang tag');
             });
         });
+
+        describe('Bold markdown (**word**) handling', () => {
+            it('strips ** markers from og:description / meta description on SSR', async () => {
+                // The SSR path depends on whether a default dataset exists. Fetch the
+                // page once up-front to see which bio source is authoritative, then
+                // write the marker-bearing bio into that same source so we know the
+                // test exercises the stripping path regardless of earlier state.
+                const currentProfile = await (await fetch(`${BASE_URL}/api/profile`)).json();
+                const bioWithBold = 'I built a **real-time** pipeline and led **three launches**.';
+                await fetch(`${BASE_URL}/api/profile`, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ ...currentProfile, bio: bioWithBold }),
+                });
+
+                const res = await fetch(`${PUBLIC_URL}/`);
+                assert.strictEqual(res.status, 200);
+                const html = await res.text();
+                // Neither meta description nor og:description should ever contain literal ** markers.
+                const metas = [...html.matchAll(/<meta\s+(?:name|property)="(?:description|og:description)"\s+content="([^"]*)"/g)];
+                assert.ok(metas.length >= 1, 'response should contain at least one description meta tag');
+                for (const m of metas) {
+                    assert.ok(
+                        !m[1].includes('**'),
+                        `meta description should not contain ** markers (got: ${m[1]})`
+                    );
+                }
+            });
+
+            it('renders **bold** as Helvetica-Bold runs in ATS PDF without literal ** markers', async () => {
+                // Seed data containing **markers** in multiple fields.
+                await fetch(`${BASE_URL}/api/profile`, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        name: 'PDF Bold Test',
+                        bio: 'Emphasize **achievements** in the summary.',
+                    }),
+                });
+                // Wipe previous seeded experience rows to keep the PDF small + predictable.
+                const existing = await (await fetch(`${BASE_URL}/api/experiences`)).json();
+                for (const e of existing) {
+                    await fetch(`${BASE_URL}/api/experiences/${e.id}`, { method: 'DELETE' });
+                }
+                await fetch(`${BASE_URL}/api/experiences`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        job_title: 'Bold Engineer',
+                        company_name: 'BoldCo',
+                        start_date: '2021-01',
+                        end_date: '',
+                        highlights: ['Shipped a **real-time** feature to millions of users'],
+                    }),
+                });
+
+                const res = await fetch(`${BASE_URL}/api/export/ats-pdf`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ scale: 1, paperSize: 'A4', locale: 'en' }),
+                });
+                assert.strictEqual(res.status, 200);
+                const buf = Buffer.from(await res.arrayBuffer());
+                const latin = buf.toString('latin1');
+
+                // Bold font must be embedded because at least one run needs it.
+                assert.ok(
+                    latin.includes('Helvetica-Bold'),
+                    'PDF should embed Helvetica-Bold font once **bold** markers appear in content'
+                );
+                // Literal ** markers must not leak through to the rendered PDF text.
+                // The raw content streams in this codebase are uncompressed text, so a
+                // substring search is a reasonable smoke test.
+                assert.ok(
+                    !/\*\*[A-Za-z]/.test(latin),
+                    'rendered PDF bytes should not contain literal "**word" sequences'
+                );
+            });
+        });
     });
 
     describe('Section title overrides', () => {

--- a/tests/frontend.test.js
+++ b/tests/frontend.test.js
@@ -649,6 +649,66 @@ describe('Frontend files', () => {
             assert.ok(result.includes('delete'), 'Should contain icon name');
         });
 
+        // --- escapeHtmlWithBold tests ---
+        it('escapeHtmlWithBold: extract and test', () => {
+            const scriptsContent = fs.readFileSync(path.join(ROOT, 'public', 'shared', 'scripts.js'), 'utf8');
+            // Extract escapeHtmlWithBold body
+            const match = scriptsContent.match(/function escapeHtmlWithBold\(text\)\s*\{[\s\S]*?\n\}/);
+            assert.ok(match, 'Should find escapeHtmlWithBold function');
+
+            // Provide a minimal polyfill for document.createElement used by escapeHtml.
+            // Mirrors the browser pattern: set textContent → read innerHTML entity-escaped.
+            const fakeDocument = {
+                createElement: () => {
+                    let _text = '';
+                    return {
+                        set textContent(v) { _text = v == null ? '' : String(v); },
+                        get innerHTML() {
+                            return _text
+                                .replace(/&/g, '&amp;')
+                                .replace(/</g, '&lt;')
+                                .replace(/>/g, '&gt;')
+                                .replace(/"/g, '&quot;')
+                                .replace(/'/g, '&#39;');
+                        }
+                    };
+                }
+            };
+            // Inline escapeHtml so it's in scope for escapeHtmlWithBold.
+            const helper = `function escapeHtml(text) {
+                if (!text) return '';
+                const div = document.createElement('div');
+                div.textContent = text;
+                return div.innerHTML;
+            }`;
+            const fn = new Function('document', `${helper}\n${match[0]}\nreturn escapeHtmlWithBold;`)(fakeDocument);
+
+            // Basic bold rendering
+            assert.strictEqual(fn('hello **world**'), 'hello <strong>world</strong>');
+            assert.strictEqual(fn('**a** and **b**'), '<strong>a</strong> and <strong>b</strong>');
+
+            // XSS safety: script tags escaped, bold still rendered
+            assert.strictEqual(
+                fn('<script>**x**</script>'),
+                '&lt;script&gt;<strong>x</strong>&lt;/script&gt;'
+            );
+
+            // Unclosed ** left literal (escaped as-is)
+            assert.strictEqual(fn('a ** b'), 'a ** b');
+
+            // ** must not span newlines
+            assert.strictEqual(fn('a **\nb**'), 'a **\nb**');
+
+            // Empty / null / undefined → ''
+            assert.strictEqual(fn(''), '');
+            assert.strictEqual(fn(null), '');
+            assert.strictEqual(fn(undefined), '');
+
+            // Plain text unchanged (apart from HTML entity escaping)
+            assert.strictEqual(fn('just plain'), 'just plain');
+            assert.strictEqual(fn('5 < 10'), '5 &lt; 10');
+        });
+
         it('materialIcon: includes aria-hidden for accessibility', () => {
             const result = materialIcon('check');
             assert.ok(result.includes('aria-hidden="true"'), 'Should include aria-hidden');

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.47.3",
+  "version": "1.48.0",
   "changelog": "https://github.com/vincentmakes/cv-manager/blob/main/CHANGELOG.md"
 }


### PR DESCRIPTION
## Description

This PR adds support for bold text formatting using `**double asterisks**` syntax across all long-form text fields in the CV Manager. Users can now wrap text in `**word**` to render it as bold in both the admin preview and public read-only site.

### Key Changes

**Frontend (`public/shared/scripts.js`)**
- New `escapeHtmlWithBold()` helper function that safely escapes HTML entities first, then converts `**text**` to `<strong>text</strong>`
- Updated all text rendering in experience cards, education, projects, and custom sections to use `escapeHtmlWithBold()` instead of plain `escapeHtml()`
- Bio field now renders with bold support via `innerHTML` instead of `textContent`

**Backend (`src/server.js`)**
- New `stripBoldMarkers()` function to remove `**` markers for plain-text contexts (SEO meta descriptions, ATS text)
- New `splitBoldRuns()` function to parse text into alternating regular/bold segments for rich PDF rendering
- Updated all meta description generation to strip bold markers before truncation
- Enhanced PDF generation to render bold runs using Helvetica-Bold font, with proper handling of multi-run text and base-bold fonts

**Admin UI (`public/shared/admin.js`)**
- Added form hints (`form.bold_hint`) to bio, experience summary/highlights, education description, and project description fields

**Internationalization**
- Added `form.bold_hint` translation key to all 8 locale files (en, de, fr, nl, es, it, pt, zh)

**Testing**
- Added comprehensive backend tests for bold marker stripping in SSR and PDF rendering
- Added frontend tests for `escapeHtmlWithBold()` covering basic bold, XSS safety, unclosed markers, newline handling, and edge cases

**Version & Changelog**
- Bumped version to 1.48.0
- Updated CHANGELOG.md with feature description

### Design Notes

The regex pattern `/\*\*([^*\n]+?)\*\*/g` ensures:
- Non-greedy matching (shortest possible bold span)
- No nested asterisks allowed
- No bold spans across newlines (prevents accidental formatting across fields)
- Consistent behavior across frontend (HTML rendering) and backend (PDF/meta generation)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

### Required for all code changes

- [x] I have tested my changes locally (`npm test` passes)
- [x] Version has been bumped in all 3 files (`package.json`, `package-lock.json`, `version.json`)
- [x] `CHANGELOG.md` has been updated with a new entry under the correct version

### If adding or changing user-visible strings

- [x] No hardcoded English — all strings use `t('key')` in JS or `data-i18n` in HTML
- [x] New i18n keys added to `en.json` and all 7 other locale files (`de`, `fr`, `nl`, `es`, `it`, `pt`, `zh`)
- [x] `escapeHtml()` used for any user-provided content rendered as HTML (via new `escapeHtmlWithBold()` wrapper)

https://claude.ai/code/session_01XGtfh6GVyPURYxmXE8zLSa