### PR TITLE
Fix cache-busting for shared scripts on public pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to CV Manager will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/), versioning follows [Semantic Versioning](https://semver.org/).
 
+## [1.48.2] - 2026-04-23
+
+### Fixed
+- **`ReferenceError: escapeHtmlWithBold is not defined` on the public read-only page after upgrading from a version prior to 1.48.0.** The `public-readonly/index.html` template's inline `renderProfileFromData`, `renderEducationFromData`, and `renderProjectsFromData` functions call `escapeHtmlWithBold`, a helper added in 1.48.0 to `public/shared/scripts.js`. The template is read from disk on every request, so returning visitors always got the new HTML that calls the helper, but `/shared/scripts.js` was served by `express.static` with no cache-buster, so their browsers kept serving the pre-1.48.0 cached copy — and the first call to `escapeHtmlWithBold` inside `loadDatasetPreview` blew up, leaving the public page blank with only the console error visible. Cache-busted both shared scripts by rewriting the `<script src>` tags in `public-readonly/index.html` to include `?v=__APP_VERSION__`, and substituting the current `package.json` version in a new `readPublicIndexHtml()` helper that now fronts all six server paths that render the template (default-dataset `/`, live-DB `/` fallback, `/` error fallback, public `/v/:slug`, admin preview `/v/:slug`, and the static-site ZIP export). Because every release is required to bump `package.json` / `version.json`, the query string changes on every upgrade and the HTML/JS pair can no longer drift for returning visitors — a stale cached `scripts.js` can never satisfy a request for the new versioned URL. No client-side changes required; the static-site export also inherits the cache-buster, so offline-hosted exports stay consistent.
+
 ## [1.48.1] - 2026-04-23
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cv-manager",
-  "version": "1.48.1",
+  "version": "1.48.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cv-manager",
-      "version": "1.48.1",
+      "version": "1.48.2",
       "dependencies": {
         "archiver": "^7.0.1",
         "better-sqlite3": "^9.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cv-manager",
-  "version": "1.48.1",
+  "version": "1.48.2",
   "description": "Professional CV Management System",
   "main": "src/server.js",
   "scripts": {

--- a/public-readonly/index.html
+++ b/public-readonly/index.html
@@ -121,8 +121,8 @@
         </section>
     </div>
 
-    <script src="/shared/i18n.js"></script>
-    <script src="/shared/scripts.js"></script>
+    <script src="/shared/i18n.js?v=__APP_VERSION__"></script>
+    <script src="/shared/scripts.js?v=__APP_VERSION__"></script>
     <script>
         // Public site initialization - read-only, no private data
         let sectionOrder = [];

--- a/src/server.js
+++ b/src/server.js
@@ -16,6 +16,16 @@ const PUBLIC_PORT = process.env.PUBLIC_PORT || 3001;
 // Version from package.json
 const CURRENT_VERSION = require(path.join(__dirname, '..', 'package.json')).version;
 
+// Read the public-readonly template and stamp the current app version into the
+// shared-script query strings. Cache-busts /shared/scripts.js and /shared/i18n.js
+// on every release so returning visitors can't pair new HTML with a stale cached
+// JS bundle.
+const PUBLIC_INDEX_HTML_PATH = path.join(__dirname, '../public-readonly/index.html');
+function readPublicIndexHtml() {
+    const html = fs.readFileSync(PUBLIC_INDEX_HTML_PATH, 'utf8');
+    return html.replace(/__APP_VERSION__/g, CURRENT_VERSION);
+}
+
 // Cached version check (in-memory only, never persisted)
 let versionCache = { latest: null, checkedAt: null, changelog: null };
 const VERSION_CHECK_INTERVAL = 24 * 60 * 60 * 1000; // 24 hours
@@ -252,7 +262,7 @@ function servePublicIndex(req, res) {
             const description = stripBoldMarkers(bio).substring(0, 160).replace(/\n/g, ' ');
             const dsLang = defaultDataset.language || 'en';
 
-            let html = fs.readFileSync(path.join(__dirname, '../public-readonly/index.html'), 'utf8');
+            let html = readPublicIndexHtml();
             html = html.replace(/<html lang="[^"]*"/, `<html lang="${dsLang}"`);
             html = html.replace(/<title>[^<]*<\/title>/, `<title>${name} - CV</title>`);
             html = html.replace(/<meta name="description" content="[^"]*">/, `<meta name="description" content="${description.replace(/"/g, '&quot;')}">`);
@@ -286,7 +296,7 @@ function servePublicIndex(req, res) {
         const bio = profile?.bio || 'Professional CV';
         const description = stripBoldMarkers(bio).substring(0, 160).replace(/\n/g, ' ');
 
-        let html = fs.readFileSync(path.join(__dirname, '../public-readonly/index.html'), 'utf8');
+        let html = readPublicIndexHtml();
         html = html.replace(/<title>[^<]*<\/title>/, `<title>${name} - CV</title>`);
         html = html.replace(/<meta name="description" content="[^"]*">/, `<meta name="description" content="${description.replace(/"/g, '&quot;')}">`);
 
@@ -310,7 +320,7 @@ function servePublicIndex(req, res) {
         html = html.replace('</head>', `${themeScript}</head>`);
 
         res.type('html').send(html);
-    } catch (err) { res.sendFile(path.join(__dirname, '../public-readonly/index.html')); }
+    } catch (err) { res.type('html').send(readPublicIndexHtml()); }
 }
 
 // Serve a public dataset page by slug (for /v/:slug on public server)
@@ -325,7 +335,7 @@ function serveDatasetPage(req, res, lang) {
         const description = stripBoldMarkers(bio).substring(0, 160).replace(/\n/g, ' ');
         const dsLang = dataset.language || 'en';
 
-        let html = fs.readFileSync(path.join(__dirname, '../public-readonly/index.html'), 'utf8');
+        let html = readPublicIndexHtml();
         html = html.replace(/<html lang="[^"]*"/, `<html lang="${dsLang}"`);
         html = html.replace(/<title>[^<]*<\/title>/, `<title>${name} - CV (${dataset.name})</title>`);
         html = html.replace(/<meta name="description" content="[^"]*">/, `<meta name="description" content="${description.replace(/"/g, '&quot;')}">`);
@@ -1563,7 +1573,7 @@ function serveAdminDatasetPage(req, res, lang) {
         const description = stripBoldMarkers(bio).substring(0, 160).replace(/\n/g, ' ');
         const dsLang = dataset.language || 'en';
 
-        let html = fs.readFileSync(path.join(__dirname, '../public-readonly/index.html'), 'utf8');
+        let html = readPublicIndexHtml();
         html = html.replace(/<html lang="[^"]*"/, `<html lang="${dsLang}"`);
         html = html.replace(/<title>[^<]*<\/title>/, `<title>${name} - CV (${dataset.name})</title>`);
         html = html.replace(/<meta name="description" content="[^"]*">/, `<meta name="description" content="${description.replace(/"/g, '&quot;')}">`);
@@ -3946,7 +3956,7 @@ if (PUBLIC_ONLY) {
             };
 
             // Prepare HTML
-            let html = fs.readFileSync(path.join(__dirname, '../public-readonly/index.html'), 'utf8');
+            let html = readPublicIndexHtml();
 
             // Inject meta tags
             const name = profile.name || 'CV';

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.48.1",
+  "version": "1.48.2",
   "changelog": "https://github.com/vincentmakes/cv-manager/blob/main/CHANGELOG.md"
 }


### PR DESCRIPTION
## Description

Fixes a critical bug where returning visitors could experience a blank public page after upgrading from versions prior to 1.48.0. The issue occurred because `public-readonly/index.html` was updated to call `escapeHtmlWithBold()` (added in 1.48.0), but `/shared/scripts.js` was served without cache-busting, causing browsers to serve stale pre-1.48.0 cached copies that lacked this helper function.

This PR implements cache-busting by:
1. Adding version query strings (`?v=__APP_VERSION__`) to the `<script src>` tags in `public-readonly/index.html`
2. Creating a new `readPublicIndexHtml()` helper that substitutes the current app version from `package.json` into these query strings
3. Updating all six server paths that render the template to use this helper instead of directly reading the file

Since every release bumps the version, the query string changes on every upgrade, ensuring the HTML/JS pair can no longer drift for returning visitors.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

### Required for all code changes

- [x] I have tested my changes locally (`npm test` passes)
- [x] Version has been bumped in all 3 files (`package.json`, `package-lock.json`, `version.json`)
- [x] `CHANGELOG.md` has been updated with a new entry under the correct version

### If adding or changing user-visible strings

- [x] No user-visible strings added or changed

### If documentation-only change

- [x] Not applicable

## Test Plan

The fix ensures that on every release, the version query string in the script tags changes, forcing browsers to fetch fresh copies of `/shared/scripts.js` and `/shared/i18n.js`. This can be verified by:
1. Checking that the HTML served includes the correct version in script query strings
2. Confirming that the public page loads without errors after an upgrade
3. Verifying that the static-site ZIP export also includes the cache-buster

https://claude.ai/code/session_01DqdogmpcAsVEp2R8j481ET