### PR TITLE
Fix certification link button visibility when printing CV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to CV Manager will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/), versioning follows [Semantic Versioning](https://semver.org/).
 
+## [1.48.4] - 2026-04-24
+
+### Fixed
+- **Certification credential link button is now preserved when printing.** The small "open in new tab" icon rendered next to each certification name (`.cert-link`) was hidden by `.cert-link { display: none; }` inside the `@media print` block of `public/shared/styles.css`, so users printing their CV — or exporting a PDF via the browser print dialog — lost the visual cue indicating that a certification has a credential URL attached. Removed the rule so the link element participates in the printed layout like every other item inside `.cert-header`, keeping print output consistent with the on-screen rendering used on both the admin preview and the public read-only page. Affects both the edit/view mode in `public/index.html` and the public-facing `public-readonly/index.html`, which share the same stylesheet. No HTML, JS, or server-side changes required; the cert-link's existing 22×22 box and inner 12px Material icon already print cleanly at the reduced cert-card size used by the print media query.
+
 ## [1.48.3] - 2026-04-23
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cv-manager",
-  "version": "1.48.3",
+  "version": "1.48.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cv-manager",
-      "version": "1.48.3",
+      "version": "1.48.4",
       "dependencies": {
         "archiver": "^7.0.1",
         "better-sqlite3": "^9.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cv-manager",
-  "version": "1.48.3",
+  "version": "1.48.4",
   "description": "Professional CV Management System",
   "main": "src/server.js",
   "scripts": {

--- a/public/shared/styles.css
+++ b/public/shared/styles.css
@@ -1947,7 +1947,6 @@ body.has-preview-banner .container {
     .cert-card.has-logo { gap: 6px; }
     .cert-logo { width: 24px; height: 24px; }
     .cert-name { font-size: 11px; }
-    .cert-link { display: none; }
     .cert-date { font-size: 9px; }
     .cert-provider { font-size: 10px; }
     

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.48.3",
+  "version": "1.48.4",
   "changelog": "https://github.com/vincentmakes/cv-manager/blob/main/CHANGELOG.md"
 }


### PR DESCRIPTION
## Description

Removes the `display: none` rule that was hiding the certification credential link button (`.cert-link`) in the `@media print` block of `public/shared/styles.css`. 

When users printed their CV or exported a PDF via the browser print dialog, the small "open in new tab" icon next to each certification name was hidden, losing the visual cue that a certification has a credential URL attached. The link element now participates in the printed layout like every other item in `.cert-header`, keeping print output consistent with on-screen rendering.

The cert-link's existing 22×22 box and 12px Material icon already print cleanly at the reduced cert-card size used by the print media query, so no HTML, JS, or server-side changes are required.

Affects both the edit/view mode in `public/index.html` and the public-facing `public-readonly/index.html`, which share the same stylesheet.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (changes to docs only — no version bump needed)
- [ ] Translation (new or updated language files)
- [ ] Refactoring (no functional changes)

## Checklist

### Required for all code changes

- [x] I have tested my changes locally (`npm test` passes)
- [x] Version has been bumped in all 3 files (`package.json`, `package-lock.json`, `version.json`)
- [x] `CHANGELOG.md` has been updated with a new entry under the correct version

### If adding or changing user-visible strings

- [x] No user-visible strings added or changed

### If documentation-only change

- [x] Not a documentation-only change

https://claude.ai/code/session_01KZ8XmvbDXTHQVPaJSgDKgj