### PR TITLE
Auto-open Save As modal after importing CV data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to CV Manager will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/), versioning follows [Semantic Versioning](https://semver.org/).
 
+## [1.49.1] - 2026-05-02
+
+### Changed
+- **Importing a CV now opens the Save As modal automatically.** Imported data wholesale-replaces the live state and is unattached to any saved dataset, so the obvious next step is to save it under a name. After a successful import the CV Manager / Save As modal opens with the name input pre-filled to the imported file's filename (without the `.json` extension), focused and selected so the user can either confirm or type over it. The language picker is already preselected to the imported file's `language` field by the existing `openCvManager` flow.
+
 ## [1.49.0] - 2026-04-27
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cv-manager",
-  "version": "1.49.0",
+  "version": "1.49.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cv-manager",
-      "version": "1.49.0",
+      "version": "1.49.1",
       "dependencies": {
         "archiver": "^7.0.1",
         "better-sqlite3": "^9.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cv-manager",
-  "version": "1.49.0",
+  "version": "1.49.1",
   "description": "Professional CV Management System",
   "main": "src/server.js",
   "scripts": {

--- a/public/shared/admin.js
+++ b/public/shared/admin.js
@@ -2108,6 +2108,17 @@ async function importData(event) {
             activeDatasetLanguage = importedLang;
             await initAdmin();
             toast(t('toast.imported'));
+
+            // Imported data isn't attached to a dataset; prompt to save it.
+            const suggestedName = file.name.replace(/\.json$/i, '');
+            await openCvManager();
+            const input = document.getElementById('saveAsNameInput');
+            if (input) {
+                input.value = suggestedName;
+                input.focus();
+                input.select();
+            }
+            updateSaveAsSubmitState();
         } catch (err) {
             toast(t('toast.invalid_file'), 'error');
         }

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.49.0",
+  "version": "1.49.1",
   "changelog": "https://github.com/vincentmakes/cv-manager/blob/main/CHANGELOG.md"
 }


### PR DESCRIPTION
## Description

When users import a CV file, the imported data replaces the current state but isn't attached to any saved dataset. This PR improves the UX by automatically opening the Save As modal after a successful import, with the filename (minus `.json` extension) pre-filled, focused, and selected in the name input field. This guides users toward the obvious next step: saving the imported data under a name.

The language is already pre-selected by the existing `openCvManager` flow based on the imported file's `language` field.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

### Required for all code changes

- [x] I have tested my changes locally (`npm test` passes)
- [x] Version has been bumped in all 3 files (`package.json`, `package-lock.json`, `version.json`)
- [x] `CHANGELOG.md` has been updated with a new entry under the correct version

### If adding or changing user-visible strings

- [x] No new user-visible strings added (uses existing modal and input elements)

## Test Plan

Manual testing:
1. Import a CV file (e.g., `my-cv.json`)
2. Verify the Save As modal opens automatically
3. Verify the name input is pre-filled with `my-cv` (without `.json`)
4. Verify the input is focused and selected
5. Confirm the language picker shows the imported file's language

https://claude.ai/code/session_0113pDyRC3C4B48d8C8MxPYx