### PR TITLE
Fix public site deindexing by Google: SSR CV content and move preview banner to JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to CV Manager will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/), versioning follows [Semantic Versioning](https://semver.org/).
 
+## [1.49.3] - 2026-05-05
+
+### Fixed
+- **Public site was being deindexed by Google after the multi-language rollout.** Two issues combined into a strong "don't index" signal:
+    1. The admin "Preview Mode — This is a saved version and not publicly accessible" banner was hardcoded into `public-readonly/index.html` and only hidden via CSS. Crawlers read hidden text, so every public page advertised itself as not publicly accessible — a textbook soft-404 signal that caused Google to drop the URL even after re-indexing requests.
+    2. The public homepage was a near-empty shell server-side: `<h1>Loading…</h1>` with empty section containers. All CV content was hydrated client-side, but Googlebot frequently skips the second render pass on low-authority subdomains and treated the page as thin content.
+
+  The preview banner DOM is now built and inserted from JavaScript only when `window.DATASET_PREVIEW` is true (admin preview context), so its text never appears in HTML served to public visitors. `servePublicIndex` and `serveDatasetPage` in `src/server.js` now server-render the profile, about, experience, certifications, education, skills, and projects sections into the HTML before sending — the client JS still hydrates the same nodes on load, so behaviour is unchanged for users while crawlers see real CV content on first byte. Also set `<html lang>` correctly in the live-DB fallback path (it was already correct on the default-dataset path).
+
 ## [1.49.2] - 2026-05-04
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cv-manager",
-  "version": "1.49.2",
+  "version": "1.49.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cv-manager",
-      "version": "1.49.2",
+      "version": "1.49.3",
       "dependencies": {
         "archiver": "^7.0.1",
         "better-sqlite3": "^9.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cv-manager",
-  "version": "1.49.2",
+  "version": "1.49.3",
   "description": "Professional CV Management System",
   "main": "src/server.js",
   "scripts": {

--- a/public-readonly/index.html
+++ b/public-readonly/index.html
@@ -29,18 +29,6 @@
         <div class="public-lang-dropdown" id="publicLangDropdown"></div>
     </div>
 
-    <!-- Preview Banner (only shown for versioned dataset URLs) -->
-    <div class="preview-banner no-print" id="previewBanner" style="display: none;">
-        <div class="preview-banner-content">
-            <span class="material-symbols-outlined" style="font-size:18px">visibility</span>
-            <span class="preview-banner-text">Preview Mode — This is a saved version and not publicly accessible</span>
-        </div>
-        <a href="/" class="preview-banner-btn">
-            <span class="material-symbols-outlined" style="font-size:14px">arrow_back</span>
-            Back to Admin
-        </a>
-    </div>
-    
     <div class="container" role="main">
         <!-- ATS-friendly hidden text version -->
         <div id="ats-content" class="ats-only" aria-hidden="true"></div>
@@ -295,9 +283,11 @@
                     return;
                 }
                 
-                // Show preview banner only in admin preview mode (not on public-facing versioned URLs)
+                // Show preview banner only in admin preview mode (not on public-facing versioned URLs).
+                // Banner DOM is built here rather than shipped in the HTML so the banner copy
+                // never appears in raw HTML on canonical public pages (a soft-404 SEO signal).
                 if (window.DATASET_PREVIEW) {
-                    document.getElementById('previewBanner').style.display = 'flex';
+                    injectPreviewBanner();
                     document.body.classList.add('has-preview-banner');
                 }
                 
@@ -373,6 +363,24 @@
             }
         }
         
+        function injectPreviewBanner() {
+            if (document.getElementById('previewBanner')) return;
+            const banner = document.createElement('div');
+            banner.className = 'preview-banner no-print';
+            banner.id = 'previewBanner';
+            banner.style.display = 'flex';
+            banner.innerHTML = `
+                <div class="preview-banner-content">
+                    <span class="material-symbols-outlined" style="font-size:18px">visibility</span>
+                    <span class="preview-banner-text">${escapeHtml(t('preview.banner_text'))}</span>
+                </div>
+                <a href="/" class="preview-banner-btn">
+                    <span class="material-symbols-outlined" style="font-size:14px">arrow_back</span>
+                    ${escapeHtml(t('preview.back_to_admin'))}
+                </a>`;
+            document.body.insertBefore(banner, document.body.firstChild);
+        }
+
         // Render functions for dataset data
         function renderProfileFromData(p) {
             if (!p) return;

--- a/public/shared/i18n/de.json
+++ b/public/shared/i18n/de.json
@@ -519,6 +519,8 @@
     "datasets.make_private": "Privat machen",
     "datasets.make_shared": "Freigeben",
     "datasets.preview": "Vorschau",
+    "preview.banner_text": "Vorschaumodus — Dies ist eine gespeicherte Version und nicht öffentlich zugänglich",
+    "preview.back_to_admin": "Zurück zur Verwaltung",
     "datasets.copy_url": "URL kopieren",
     "ats.english_headers": "Abschnittsüberschriften auf Englisch",
     "datasets.legend_default": "Wird auf der öffentlichen Seite angezeigt",

--- a/public/shared/i18n/en.json
+++ b/public/shared/i18n/en.json
@@ -309,6 +309,8 @@
     "datasets.make_private": "Make private",
     "datasets.make_shared": "Make shared",
     "datasets.preview": "Preview",
+    "preview.banner_text": "Preview Mode — This is a saved version and not publicly accessible",
+    "preview.back_to_admin": "Back to Admin",
     "datasets.copy_url": "Copy URL",
     "datasets.legend.radio": "select which dataset visitors see at your root URL",
     "datasets.legend.toggle": "share other datasets at their own /v/slug URL",

--- a/public/shared/i18n/es.json
+++ b/public/shared/i18n/es.json
@@ -519,6 +519,8 @@
     "datasets.make_private": "Hacer privado",
     "datasets.make_shared": "Compartir",
     "datasets.preview": "Vista previa",
+    "preview.banner_text": "Modo vista previa — Esta es una versión guardada y no es accesible públicamente",
+    "preview.back_to_admin": "Volver a la administración",
     "datasets.copy_url": "Copiar URL",
     "ats.english_headers": "Encabezados de sección en inglés",
     "datasets.legend_default": "Publicado en el sitio público",

--- a/public/shared/i18n/fr.json
+++ b/public/shared/i18n/fr.json
@@ -519,6 +519,8 @@
     "datasets.make_private": "Rendre privé",
     "datasets.make_shared": "Partager",
     "datasets.preview": "Aperçu",
+    "preview.banner_text": "Mode aperçu — Ceci est une version enregistrée et n'est pas accessible publiquement",
+    "preview.back_to_admin": "Retour à l'administration",
     "datasets.copy_url": "Copier l'URL",
     "ats.english_headers": "Titres de section en anglais",
     "datasets.legend_default": "Affiché sur le site public",

--- a/public/shared/i18n/it.json
+++ b/public/shared/i18n/it.json
@@ -519,6 +519,8 @@
     "datasets.make_private": "Rendi privato",
     "datasets.make_shared": "Condividi",
     "datasets.preview": "Anteprima",
+    "preview.banner_text": "Modalità anteprima — Questa è una versione salvata e non è accessibile pubblicamente",
+    "preview.back_to_admin": "Torna all'amministrazione",
     "datasets.copy_url": "Copia URL",
     "ats.english_headers": "Intestazioni sezione in inglese",
     "datasets.legend_default": "Mostrato sul sito pubblico",

--- a/public/shared/i18n/nl.json
+++ b/public/shared/i18n/nl.json
@@ -519,6 +519,8 @@
     "datasets.make_private": "Privé maken",
     "datasets.make_shared": "Delen",
     "datasets.preview": "Voorbeeld",
+    "preview.banner_text": "Voorbeeldmodus — Dit is een opgeslagen versie en niet publiekelijk toegankelijk",
+    "preview.back_to_admin": "Terug naar beheer",
     "datasets.copy_url": "URL kopiëren",
     "ats.english_headers": "Sectiekoppen in het Engels",
     "datasets.legend_default": "Weergegeven op de publieke site",

--- a/public/shared/i18n/pt.json
+++ b/public/shared/i18n/pt.json
@@ -519,6 +519,8 @@
     "datasets.make_private": "Tornar privado",
     "datasets.make_shared": "Compartilhar",
     "datasets.preview": "Visualizar",
+    "preview.banner_text": "Modo de visualização — Esta é uma versão salva e não está acessível publicamente",
+    "preview.back_to_admin": "Voltar à administração",
     "datasets.copy_url": "Copiar URL",
     "ats.english_headers": "Cabeçalhos de secção em inglês",
     "datasets.legend_default": "Exibido no site público",

--- a/public/shared/i18n/zh.json
+++ b/public/shared/i18n/zh.json
@@ -519,6 +519,8 @@
     "datasets.make_private": "设为私密",
     "datasets.make_shared": "设为共享",
     "datasets.preview": "预览",
+    "preview.banner_text": "预览模式 — 这是已保存的版本，未公开访问",
+    "preview.back_to_admin": "返回管理后台",
     "datasets.copy_url": "复制链接",
     "ats.english_headers": "章节标题使用英文",
     "datasets.legend_default": "显示在公开网站上",

--- a/src/server.js
+++ b/src/server.js
@@ -287,6 +287,201 @@ function isTrackingConsentRequired() {
     } catch (e) { return false; }
 }
 
+function escapeHtmlServer(text) {
+    if (text == null) return '';
+    return String(text)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+// Pull the current live CV into the same shape as a saved-dataset blob so
+// the SSR helper has one input format to deal with.
+function gatherLiveCvData() {
+    try {
+        const profile = db.prepare('SELECT name, initials, title, subtitle, bio, location, linkedin, languages, profile_picture_enabled, picture_filename FROM profile WHERE id = 1').get() || {};
+        const experiences = db.prepare('SELECT id, job_title, company_name, start_date, end_date, location, country_code, highlights, summary, logo_filename FROM experiences WHERE visible = 1 ORDER BY sort_order ASC, start_date DESC').all().map(e => ({ ...e, highlights: e.highlights ? JSON.parse(e.highlights) : [] }));
+        const certifications = db.prepare('SELECT name, provider, issue_date, expiry_date, credential_id, logo_filename FROM certifications WHERE visible = 1 ORDER BY sort_order ASC, issue_date DESC').all();
+        const education = db.prepare('SELECT degree_title, institution_name, start_date, end_date, description, logo_filename FROM education WHERE visible = 1 ORDER BY sort_order ASC, end_date DESC').all();
+        const skillCategories = db.prepare('SELECT id, name, icon FROM skill_categories WHERE visible = 1 ORDER BY sort_order ASC').all();
+        const skillRows = db.prepare('SELECT * FROM skills ORDER BY sort_order ASC').all();
+        const skills = skillCategories.map(cat => ({ ...cat, skills: skillRows.filter(s => s.category_id === cat.id).map(s => s.name) }));
+        const projects = db.prepare('SELECT title, description, technologies, link FROM projects WHERE visible = 1 ORDER BY sort_order ASC').all().map(p => ({ ...p, technologies: p.technologies ? JSON.parse(p.technologies) : [] }));
+        const sectionRows = db.prepare('SELECT section_name, visible FROM section_visibility').all();
+        const sectionVisibility = {};
+        sectionRows.forEach(s => { sectionVisibility[s.section_name] = !!s.visible; });
+        return { profile, experiences, certifications, education, skills, projects, sectionVisibility };
+    } catch (err) {
+        return null;
+    }
+}
+
+// Server-render the CV body into the public template before sending. The
+// client JS hydrates the same nodes on load (overwriting our HTML), so this
+// only affects what crawlers and JS-disabled visitors see.
+//
+// Why this exists: Googlebot does not always run the page's JavaScript on
+// low-authority subdomains. Without SSR, the public homepage was a near-empty
+// shell with `<h1>Loading…</h1>` and empty section containers — Google
+// classified it as thin content and silently deindexed it. SSR gives crawlers
+// real CV text on first byte so the page can be indexed properly.
+function injectPublicBodySSR(html, data) {
+    if (!data) return html;
+    const e = escapeHtmlServer;
+    const profile = data.profile || {};
+    const sectionVisibility = data.sectionVisibility || {};
+
+    const name = profile.name ? e(profile.name) : '';
+    if (name) {
+        html = html.replace(
+            /<h1 class="profile-name" id="profileName" itemprop="name">[^<]*<\/h1>/,
+            `<h1 class="profile-name" id="profileName" itemprop="name">${name}</h1>`
+        );
+    }
+    if (profile.title) {
+        html = html.replace(
+            /<p class="profile-title" id="profileTitle" itemprop="jobTitle"><\/p>/,
+            `<p class="profile-title" id="profileTitle" itemprop="jobTitle">${e(profile.title)}</p>`
+        );
+    }
+    if (profile.subtitle) {
+        html = html.replace(
+            /<p class="profile-subtitle" id="profileSubtitle"><\/p>/,
+            `<p class="profile-subtitle" id="profileSubtitle">${e(profile.subtitle)}</p>`
+        );
+    }
+
+    const badges = [];
+    if (profile.location) badges.push(`<span class="contact-badge" itemprop="address">${e(profile.location)}</span>`);
+    if (profile.linkedin) badges.push(`<a href="${e(profile.linkedin)}" class="contact-badge" target="_blank" rel="noopener" itemprop="url">LinkedIn</a>`);
+    if (profile.languages) badges.push(`<span class="contact-badge">${e(profile.languages)}</span>`);
+    if (badges.length) {
+        html = html.replace(
+            /<address class="contact-badges" id="contactBadges"><\/address>/,
+            `<address class="contact-badges" id="contactBadges">${badges.join('')}</address>`
+        );
+    }
+
+    if (profile.bio) {
+        const bioText = stripBoldMarkers(profile.bio);
+        const aboutHtml = bioText.split(/\n\s*\n/).map(p => `<p>${e(p).replace(/\n/g, '<br>')}</p>`).join('');
+        html = html.replace(
+            /<div class="about-text" id="aboutText" itemprop="description"><\/div>/,
+            `<div class="about-text" id="aboutText" itemprop="description">${aboutHtml}</div>`
+        );
+    }
+
+    const experiences = (data.experiences || []).filter(x => x.visible !== false);
+    if (experiences.length) {
+        const expHtml = experiences.map(exp => {
+            const period = formatPeriod(exp.start_date, exp.end_date);
+            const summary = exp.summary ? `<div class="item-summary">${e(stripBoldMarkers(exp.summary))}</div>` : '';
+            const highlights = Array.isArray(exp.highlights) && exp.highlights.length
+                ? `<ul class="item-highlights">${exp.highlights.map(h => `<li>${e(stripBoldMarkers(h))}</li>`).join('')}</ul>`
+                : '';
+            const location = exp.location ? `<div class="item-location">${e(exp.location)}</div>` : '';
+            return `<article class="item-card" itemscope itemtype="https://schema.org/WorkExperience">
+                <div class="item-header">
+                    <div>
+                        <h3 class="item-title" itemprop="jobTitle">${e(exp.job_title || '')}</h3>
+                        <div class="item-subtitle"><span itemprop="worksFor">${e(exp.company_name || '')}</span></div>
+                    </div>
+                    <span class="item-date">${e(period)}</span>
+                </div>
+                ${location}
+                ${summary}
+                ${highlights}
+            </article>`;
+        }).join('');
+        html = html.replace(
+            /<div class="items-list" id="experienceList"><\/div>/,
+            `<div class="items-list" id="experienceList">${expHtml}</div>`
+        );
+    }
+
+    const certs = (data.certifications || []).filter(c => c.visible !== false);
+    if (certs.length) {
+        const certHtml = certs.map(cert => `
+            <article class="cert-card" itemscope itemtype="https://schema.org/EducationalOccupationalCredential">
+                <div class="cert-content">
+                    <div class="cert-header">
+                        <div class="cert-name" itemprop="name">${e(cert.name || '')}</div>
+                    </div>
+                    <time class="cert-date" itemprop="dateCreated">${e(formatDateShort(cert.issue_date) || '')}</time>
+                    <div class="cert-provider" itemprop="issuedBy">${e(cert.provider || '')}</div>
+                </div>
+            </article>`).join('');
+        html = html.replace(
+            /<div class="cert-grid" id="certGrid"><\/div>/,
+            `<div class="cert-grid" id="certGrid">${certHtml}</div>`
+        );
+    }
+
+    const edu = (data.education || []).filter(x => x.visible !== false);
+    if (edu.length) {
+        const eduHtml = edu.map(item => {
+            const period = formatPeriod(item.start_date, item.end_date);
+            const desc = item.description ? `<div class="item-location">${e(stripBoldMarkers(item.description))}</div>` : '';
+            return `<article class="item-card" itemscope itemtype="https://schema.org/EducationalOccupationalCredential">
+                <div class="item-header">
+                    <div>
+                        <h3 class="item-title" itemprop="name">${e(item.degree_title || '')}</h3>
+                        <div class="item-subtitle"><span itemprop="name">${e(item.institution_name || '')}</span></div>
+                    </div>
+                    <span class="item-date">${e(period)}</span>
+                </div>
+                ${desc}
+            </article>`;
+        }).join('');
+        html = html.replace(
+            /<div class="items-list" id="educationList"><\/div>/,
+            `<div class="items-list" id="educationList">${eduHtml}</div>`
+        );
+    }
+
+    const skillCats = (data.skills || []).filter(s => s.visible !== false);
+    if (skillCats.length) {
+        const skillsHtml = skillCats.map(cat => `
+            <div class="skill-category">
+                <div class="skill-category-title">${e(cat.name || '')}</div>
+                <div class="skill-tags">${(cat.skills || []).map(s => `<span class="skill-tag">${e(s)}</span>`).join('')}</div>
+            </div>`).join('');
+        html = html.replace(
+            /<div class="skills-grid" id="skillsGrid"><\/div>/,
+            `<div class="skills-grid" id="skillsGrid">${skillsHtml}</div>`
+        );
+    }
+
+    const projects = (data.projects || []).filter(p => p.visible !== false);
+    if (projects.length) {
+        const projHtml = projects.map(p => `
+            <article class="project-card" itemscope itemtype="https://schema.org/CreativeWork">
+                <div class="project-header">
+                    <h3 class="project-title" itemprop="name">${e(p.title || '')}</h3>
+                </div>
+                <div class="project-description" itemprop="description">${e(stripBoldMarkers(p.description || ''))}</div>
+                <div class="tech-tags">${(p.technologies || []).map(t => `<span class="tech-tag">${e(t)}</span>`).join('')}</div>
+            </article>`).join('');
+        html = html.replace(
+            /<div class="projects-grid" id="projectsGrid"><\/div>/,
+            `<div class="projects-grid" id="projectsGrid">${projHtml}</div>`
+        );
+    }
+
+    Object.keys(sectionVisibility).forEach(key => {
+        if (sectionVisibility[key] === false) {
+            const safeKey = String(key).replace(/[^a-z0-9_-]/gi, '');
+            if (!safeKey) return;
+            const re = new RegExp(`<section class="section" id="section-${safeKey}"`, 'g');
+            html = html.replace(re, `<section class="section is-hidden" style="display:none" id="section-${safeKey}"`);
+        }
+    });
+
+    return html;
+}
+
 function servePublicIndex(req, res) {
     try {
         // Check if a default dataset exists — serve from it instead of live DB
@@ -339,16 +534,23 @@ function servePublicIndex(req, res) {
             const datasetScript = `<script>window.DATASET_ID = ${defaultDataset.id}; window.DATASET_SLUG = "${defaultDataset.slug}"; window.DATASET_LANG = "${dsLang}"; window.DATASET_IS_DEFAULT = true; window.DATASET_THEME = ${JSON.stringify(datasetTheme)};${siblings.length > 1 ? ` window.DATASET_SIBLINGS = ${JSON.stringify(siblings)};` : ''}</script>`;
             html = html.replace('</head>', `${datasetScript}</head>`);
 
+            html = injectPublicBodySSR(html, data);
             return res.type('html').send(html);
         }
 
         // Fallback: serve from live DB (no default dataset set)
-        const profile = db.prepare('SELECT name, title, bio FROM profile WHERE id = 1').get();
-        const name = profile?.name || 'CV';
-        const bio = profile?.bio || 'Professional CV';
+        const liveData = gatherLiveCvData();
+        const profile = liveData?.profile || {};
+        const name = profile.name || 'CV';
+        const bio = profile.bio || 'Professional CV';
         const description = stripBoldMarkers(bio).substring(0, 160).replace(/\n/g, ' ');
+        const liveLang = (() => {
+            try { return db.prepare('SELECT value FROM settings WHERE key = ?').get('language')?.value || 'en'; }
+            catch (e) { return 'en'; }
+        })();
 
         let html = readPublicIndexHtml();
+        html = html.replace(/<html lang="[^"]*"/, `<html lang="${liveLang}"`);
         html = html.replace(/<title>[^<]*<\/title>/, `<title>${name} - CV</title>`);
         html = html.replace(/<meta name="description" content="[^"]*">/, `<meta name="description" content="${description.replace(/"/g, '&quot;')}">`);
 
@@ -371,6 +573,7 @@ function servePublicIndex(req, res) {
         const themeScript = `<script>window.DATASET_THEME = ${JSON.stringify(fallbackTheme)};</script>`;
         html = html.replace('</head>', `${themeScript}</head>`);
 
+        html = injectPublicBodySSR(html, liveData);
         res.type('html').send(html);
     } catch (err) { res.type('html').send(readPublicIndexHtml()); }
 }
@@ -413,6 +616,7 @@ function serveDatasetPage(req, res, lang) {
             html = html.replace('<head>', `<head>\n${trackingCode}`);
         }
 
+        html = injectPublicBodySSR(html, data);
         res.type('html').send(html);
     } catch (err) {
         if (err.message?.includes('no such column')) return res.status(404).send('Not found');

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.49.2",
+  "version": "1.49.3",
   "changelog": "https://github.com/vincentmakes/cv-manager/blob/main/CHANGELOG.md"
 }


### PR DESCRIPTION
## Description

Fixes a critical SEO issue where the public CV site was being deindexed by Google after the multi-language rollout. Two problems combined into a strong "don't index" signal:

1. **Preview banner in raw HTML**: The admin "Preview Mode — This is a saved version and not publicly accessible" banner was hardcoded into `public-readonly/index.html` and only hidden via CSS. Search crawlers read hidden text, so every public page advertised itself as not publicly accessible — a textbook soft-404 signal that caused Google to drop the URL.

2. **Thin content on public homepage**: The public homepage was a near-empty shell server-side (`<h1>Loading…</h1>` with empty section containers). All CV content was hydrated client-side, but Googlebot frequently skips the second render pass on low-authority subdomains and treated the page as thin content.

**Solution:**
- Moved preview banner DOM generation to JavaScript — it's now only inserted when `window.DATASET_PREVIEW` is true (admin preview context), so the banner text never appears in HTML served to public visitors
- Implemented server-side rendering (SSR) of CV content: `servePublicIndex()` and `serveDatasetPage()` now render profile, about, experience, certifications, education, skills, and projects sections into the HTML before sending
- Client-side JS still hydrates the same nodes on load, so user behavior is unchanged while crawlers see real CV content on first byte
- Set `<html lang>` attribute correctly from database settings on the live homepage
- Added HTML escaping utility and proper i18n keys for preview banner text

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (changes to docs only — no version bump needed)
- [ ] Translation (new or updated language files)
- [ ] Refactoring (no functional changes)

## Checklist

### Required for all code changes

- [x] I have tested my changes locally (`npm test` passes)
- [x] Version has been bumped in all 3 files (`package.json`, `package-lock.json`, `version.json`)
- [x] `CHANGELOG.md` has been updated with a new entry under the correct version

### If adding or changing user-visible strings

- [x] No hardcoded English — all strings use `t('key')` in JS or `data-i18n` in HTML
- [x] New i18n keys added to `en.json` and all 7 other locale files (`de`, `fr`, `nl`, `es`, `it`, `pt`, `zh`)
- [x] `escapeHtml()` used for any user-provided content rendered as HTML

### If documentation-only change

- [ ] No version bump included (docs changes must not bump the version)

## Test Plan

- Verify public homepage renders CV content in raw HTML (view page source)
- Verify preview banner only appears in admin preview mode (`?preview=...`), not on public pages
- Verify `<html lang>` attribute matches database language setting on live homepage
- Verify client-side hydration still works (page remains interactive after load)
- Verify all 8 language files have new i18n keys for preview banner

https://claude.ai/code/session_012QpBLqtiKoHg8mVfqXLwDj