### PR TITLE
Add canonical link injection to public CV pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to CV Manager will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/), versioning follows [Semantic Versioning](https://semver.org/).
 
+## [1.49.4] - 2026-05-06
+
+### Added
+- **`<link rel="canonical">` on public CV pages.** Crawlers were free to index the same CV under multiple URL variants (http vs https, with/without trailing query strings, alternate hostnames behind reverse proxies). The public root and the live-CV fallback now emit a canonical link derived from the request — honoring `X-Forwarded-Proto` and `X-Forwarded-Host` the same way `/sitemap.xml` and `/robots.txt` already do, so no extra config is required. `/v/:slug` pages emit a canonical only when `slugsIndex` is enabled; when slugs are `noindex`, the tag is intentionally omitted. Implemented as a single `buildCanonicalTag(req)` helper in `src/server.js` reused at all three SSR sites.
+
 ## [1.49.3] - 2026-05-05
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cv-manager",
-  "version": "1.49.3",
+  "version": "1.49.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cv-manager",
-      "version": "1.49.3",
+      "version": "1.49.4",
       "dependencies": {
         "archiver": "^7.0.1",
         "better-sqlite3": "^9.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cv-manager",
-  "version": "1.49.3",
+  "version": "1.49.4",
   "description": "Professional CV Management System",
   "main": "src/server.js",
   "scripts": {

--- a/src/server.js
+++ b/src/server.js
@@ -297,6 +297,16 @@ function escapeHtmlServer(text) {
         .replace(/'/g, '&#39;');
 }
 
+// Build a <link rel="canonical"> tag from the request, honoring reverse-proxy
+// headers (X-Forwarded-Proto / X-Forwarded-Host) the same way sitemap.xml /
+// robots.txt do. Uses req.path so query strings and fragments are stripped.
+function buildCanonicalTag(req) {
+    const protocol = req.headers['x-forwarded-proto'] || req.protocol || 'https';
+    const host = req.headers['x-forwarded-host'] || req.headers.host || 'localhost';
+    const url = `${protocol}://${host}${req.path}`;
+    return `    <link rel="canonical" href="${escapeHtmlServer(url)}">`;
+}
+
 // Pull the current live CV into the same shape as a saved-dataset blob so
 // the SSR helper has one input format to deal with.
 function gatherLiveCvData() {
@@ -528,6 +538,9 @@ function servePublicIndex(req, res) {
                 html = html.replace('<head>', `<head>\n${trackingCode}`);
             }
 
+            // Inject canonical link derived from the request (honors reverse-proxy headers)
+            html = html.replace('</head>', `${buildCanonicalTag(req)}\n</head>`);
+
             // Inject default dataset ID and language info (no DATASET_PREVIEW = no preview banner)
             const siblings = getDatasetSiblings(defaultDataset);
             const datasetTheme = data.theme || gatherTheme();
@@ -568,6 +581,9 @@ function servePublicIndex(req, res) {
             html = html.replace('<head>', `<head>\n${trackingCode}`);
         }
 
+        // Inject canonical link derived from the request (honors reverse-proxy headers)
+        html = html.replace('</head>', `${buildCanonicalTag(req)}\n</head>`);
+
         // Inject theme so the public page can apply font/gradient before paint
         const fallbackTheme = gatherTheme();
         const themeScript = `<script>window.DATASET_THEME = ${JSON.stringify(fallbackTheme)};</script>`;
@@ -598,17 +614,20 @@ function serveDatasetPage(req, res, lang) {
         const ogTags = `\n    <meta property="og:title" content="${name} - CV (${dataset.name})">\n    <meta property="og:description" content="${description.replace(/"/g, '&quot;')}">\n    <meta property="og:type" content="profile">`;
         html = html.replace(/<meta name="description" content="[^"]*">/, `<meta name="description" content="${description.replace(/"/g, '&quot;')}">${ogTags}`);
 
+        // Apply noindex if slugsIndex setting is not enabled; only emit canonical when indexable
+        const slugsIndexSetting = db.prepare('SELECT value FROM settings WHERE key = ?').get('slugsIndex');
+        const slugIsIndexable = slugsIndexSetting && slugsIndexSetting.value === 'true';
+        if (!slugIsIndexable) {
+            html = html.replace(/<meta name="robots"[^>]*>/, '<meta name="robots" id="metaRobots" content="noindex, nofollow">');
+        } else {
+            html = html.replace('</head>', `${buildCanonicalTag(req)}\n</head>`);
+        }
+
         // Inject dataset context with language info and exact ID
         const siblings = getDatasetSiblings(dataset);
         const datasetTheme = data.theme || gatherTheme();
         const datasetScript = `<script>window.DATASET_ID = ${dataset.id}; window.DATASET_SLUG = "${dataset.slug}"; window.DATASET_LANG = "${dsLang}"; window.DATASET_THEME = ${JSON.stringify(datasetTheme)};${siblings.length > 1 ? ` window.DATASET_SIBLINGS = ${JSON.stringify(siblings)};` : ''}</script>`;
         html = html.replace('</head>', `${datasetScript}</head>`);
-
-        // Apply noindex if slugsIndex setting is not enabled
-        const slugsIndexSetting = db.prepare('SELECT value FROM settings WHERE key = ?').get('slugsIndex');
-        if (!slugsIndexSetting || slugsIndexSetting.value !== 'true') {
-            html = html.replace(/<meta name="robots"[^>]*>/, '<meta name="robots" id="metaRobots" content="noindex, nofollow">');
-        }
 
         // Inject tracking code right after <head> (server-side for GA verification)
         const trackingCode = getTrackingCode();

--- a/tests/backend.test.js
+++ b/tests/backend.test.js
@@ -2634,6 +2634,93 @@ describe('Backend API', () => {
         });
     });
 
+    describe('Canonical link injection', () => {
+        it('emits canonical from request host on public root', async () => {
+            // Node's fetch reserves the Host header, so simulate the deployed-host
+            // case via X-Forwarded-Host (the realistic reverse-proxy path).
+            const res = await fetch(PUBLIC_URL, {
+                headers: { 'X-Forwarded-Host': 'cv.example.com' },
+            });
+            assert.strictEqual(res.status, 200);
+            const text = await res.text();
+            assert.match(text, /<link rel="canonical" href="http:\/\/cv\.example\.com\/">/);
+        });
+
+        it('honors X-Forwarded-Proto and X-Forwarded-Host', async () => {
+            const res = await fetch(PUBLIC_URL, {
+                headers: {
+                    'X-Forwarded-Proto': 'https',
+                    'X-Forwarded-Host': 'cv.example.com',
+                },
+            });
+            assert.strictEqual(res.status, 200);
+            const text = await res.text();
+            assert.match(text, /<link rel="canonical" href="https:\/\/cv\.example\.com\/">/);
+        });
+
+        it('omits canonical on /v/:slug when slugsIndex is disabled', async () => {
+            // Default state — slugsIndex unset
+            const createRes = await fetch(`${BASE_URL}/api/datasets`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name: 'Canonical NoIndex' }),
+            });
+            const created = await createRes.json();
+            await fetch(`${BASE_URL}/api/datasets/${created.id}/save`, { method: 'POST' });
+            await fetch(`${BASE_URL}/api/datasets/${created.id}/public`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ is_public: true }),
+            });
+
+            const res = await fetch(`${PUBLIC_URL}/v/${created.slug}`, {
+                headers: { 'X-Forwarded-Host': 'cv.example.com' },
+            });
+            assert.strictEqual(res.status, 200);
+            const text = await res.text();
+            assert.doesNotMatch(text, /<link rel="canonical"/);
+            assert.match(text, /<meta name="robots"[^>]*content="noindex/);
+
+            await fetch(`${BASE_URL}/api/datasets/${created.id}`, { method: 'DELETE' });
+        });
+
+        it('emits canonical on /v/:slug when slugsIndex is enabled', async () => {
+            await fetch(`${BASE_URL}/api/settings/slugsIndex`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ value: 'true' }),
+            });
+
+            const createRes = await fetch(`${BASE_URL}/api/datasets`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name: 'Canonical Indexable' }),
+            });
+            const created = await createRes.json();
+            await fetch(`${BASE_URL}/api/datasets/${created.id}/save`, { method: 'POST' });
+            await fetch(`${BASE_URL}/api/datasets/${created.id}/public`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ is_public: true }),
+            });
+
+            const res = await fetch(`${PUBLIC_URL}/v/${created.slug}`, {
+                headers: { 'X-Forwarded-Host': 'cv.example.com' },
+            });
+            assert.strictEqual(res.status, 200);
+            const text = await res.text();
+            const expected = new RegExp(`<link rel="canonical" href="http://cv\\.example\\.com/v/${created.slug}">`);
+            assert.match(text, expected);
+
+            await fetch(`${BASE_URL}/api/datasets/${created.id}`, { method: 'DELETE' });
+            await fetch(`${BASE_URL}/api/settings/slugsIndex`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ value: 'false' }),
+            });
+        });
+    });
+
     describe('Tracking consent gating', () => {
         const SNIPPET = '<script>window.__cvTrackingFlag = "yes";</script>';
 

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.49.3",
+  "version": "1.49.4",
   "changelog": "https://github.com/vincentmakes/cv-manager/blob/main/CHANGELOG.md"
 }


### PR DESCRIPTION
## Description

Adds `<link rel="canonical">` tag injection to public CV pages to prevent search engine indexing of duplicate content across URL variants. The canonical link is derived from the request and respects reverse-proxy headers (`X-Forwarded-Proto` and `X-Forwarded-Host`), consistent with how `/sitemap.xml` and `/robots.txt` are already handled.

**Behavior:**
- Public root (`/`) and live-CV fallback pages always emit a canonical link
- `/v/:slug` pages emit a canonical link only when `slugsIndex` setting is enabled
- When `slugsIndex` is disabled, `/v/:slug` pages receive `noindex, nofollow` robots meta tag instead

**Implementation:**
- New `buildCanonicalTag(req)` helper function in `src/server.js` that constructs the canonical URL from request headers and path
- Canonical injection applied at all three SSR injection points in `servePublicIndex()` and `serveDatasetPage()`
- Query strings and fragments are stripped (uses `req.path`)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

### Required for all code changes

- [x] I have tested my changes locally (`npm test` passes)
- [x] Version has been bumped in all 3 files (`package.json`, `package-lock.json`, `version.json`)
- [x] `CHANGELOG.md` has been updated with a new entry under the correct version

### If adding or changing user-visible strings

- [x] No user-visible strings added (canonical links are SEO metadata, not UI text)

## Test Coverage

Added comprehensive test suite covering:
- Canonical link emission on public root with `X-Forwarded-Host`
- Protocol and host header handling (`X-Forwarded-Proto` and `X-Forwarded-Host`)
- Canonical omission on `/v/:slug` when `slugsIndex` is disabled (with `noindex` verification)
- Canonical emission on `/v/:slug` when `slugsIndex` is enabled

All tests pass with `npm test`.

https://claude.ai/code/session_01EGykcv9Yvem218n13TqYhz